### PR TITLE
refactor: Phase 1 — shared foundations (pure addition, zero behavior change)

### DIFF
--- a/src/app/api/admin/companies/[id]/route.ts
+++ b/src/app/api/admin/companies/[id]/route.ts
@@ -1,31 +1,11 @@
 // src/app/api/admin/companies/[id]/route.ts
 
 import { NextResponse, type NextRequest } from "next/server";
-import { getUser } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAdmin } from "@/lib/auth";
+import { VALID_ATS } from "@/lib/constants";
 import type { ATSType } from "@/lib/types";
-
 import type { Database } from "@/lib/database.types";
-
-const VALID_ATS: ATSType[] = [
-  "greenhouse",
-  "lever",
-  "ashby",
-  "workable",
-  "teamtailor",
-  "breezy",
-  "smartrecruiters",
-  "bamboohr",
-  "jazzhr",
-];
-
-async function requireAdmin() {
-  const user = await getUser();
-  if (!user) return null;
-  const db = createAdminClient();
-  const { data } = await db.from("user_profiles").select("role").eq("id", user.id).single();
-  return data?.role === "admin" ? user : null;
-}
 
 export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
   const admin = await requireAdmin();

--- a/src/app/api/admin/companies/route.ts
+++ b/src/app/api/admin/companies/route.ts
@@ -1,29 +1,10 @@
 // src/app/api/admin/companies/route.ts
 
 import { NextResponse, type NextRequest } from "next/server";
-import { getUser } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAdmin } from "@/lib/auth";
+import { VALID_ATS } from "@/lib/constants";
 import type { ATSType } from "@/lib/types";
-
-const VALID_ATS: ATSType[] = [
-  "greenhouse",
-  "lever",
-  "ashby",
-  "workable",
-  "teamtailor",
-  "breezy",
-  "smartrecruiters",
-  "bamboohr",
-  "jazzhr",
-];
-
-async function requireAdmin() {
-  const user = await getUser();
-  if (!user) return null;
-  const db = createAdminClient();
-  const { data } = await db.from("user_profiles").select("role").eq("id", user.id).single();
-  return data?.role === "admin" ? user : null;
-}
 
 export async function GET() {
   const admin = await requireAdmin();

--- a/src/app/api/admin/defaults/route.ts
+++ b/src/app/api/admin/defaults/route.ts
@@ -1,19 +1,10 @@
 // src/app/api/admin/defaults/route.ts
 
 import { NextResponse, type NextRequest } from "next/server";
-import { getUser } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAdmin } from "@/lib/auth";
 import { getDefaultSettings } from "@/lib/settings";
-
 import type { Database } from "@/lib/database.types";
-
-async function requireAdmin() {
-  const user = await getUser();
-  if (!user) return null;
-  const db = createAdminClient();
-  const { data } = await db.from("user_profiles").select("role").eq("id", user.id).single();
-  return data?.role === "admin" ? user : null;
-}
 
 export async function GET() {
   const admin = await requireAdmin();

--- a/src/app/api/admin/submissions/[id]/route.ts
+++ b/src/app/api/admin/submissions/[id]/route.ts
@@ -1,18 +1,9 @@
 // src/app/api/admin/submissions/[id]/route.ts
 
 import { NextResponse, type NextRequest } from "next/server";
-import { getUser } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
-
+import { requireAdmin } from "@/lib/auth";
 import type { Database } from "@/lib/database.types";
-
-async function requireAdmin() {
-  const user = await getUser();
-  if (!user) return null;
-  const db = createAdminClient();
-  const { data } = await db.from("user_profiles").select("role").eq("id", user.id).single();
-  return data?.role === "admin" ? user : null;
-}
 
 // ── PATCH — approve / reject / edit a submission ─────────────
 

--- a/src/app/api/admin/submissions/route.ts
+++ b/src/app/api/admin/submissions/route.ts
@@ -1,16 +1,8 @@
 // src/app/api/admin/submissions/route.ts
 
 import { NextResponse } from "next/server";
-import { getUser } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
-
-async function requireAdmin() {
-  const user = await getUser();
-  if (!user) return null;
-  const db = createAdminClient();
-  const { data } = await db.from("user_profiles").select("role").eq("id", user.id).single();
-  return data?.role === "admin" ? user : null;
-}
+import { requireAdmin } from "@/lib/auth";
 
 export async function GET() {
   const admin = await requireAdmin();

--- a/src/app/api/admin/test-ats/route.ts
+++ b/src/app/api/admin/test-ats/route.ts
@@ -3,19 +3,11 @@
 // No jobs are stored. Result is written back to ats_submissions.test_result.
 
 import { NextResponse, type NextRequest } from "next/server";
-import { getUser } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { requireAdmin } from "@/lib/auth";
 import { fetchCompany } from "@/lib/ats-bridge";
 import type { ATSCompanyRow, ATSTestResult, ATSType } from "@/lib/types";
 import type { Json } from "@/lib/database.types";
-
-async function requireAdmin() {
-  const user = await getUser();
-  if (!user) return null;
-  const db = createAdminClient();
-  const { data } = await db.from("user_profiles").select("role").eq("id", user.id).single();
-  return data?.role === "admin" ? user : null;
-}
 
 export async function POST(request: NextRequest) {
   const admin = await requireAdmin();

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -3,18 +3,9 @@
 // Role escalation is explicitly forbidden — `role` is stripped from all payloads.
 
 import { NextResponse, type NextRequest } from "next/server";
-import { getUser } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
-
+import { requireAdmin } from "@/lib/auth";
 import type { Database } from "@/lib/database.types";
-
-async function requireAdmin() {
-  const user = await getUser();
-  if (!user) return null;
-  const db = createAdminClient();
-  const { data } = await db.from("user_profiles").select("role").eq("id", user.id).single();
-  return data?.role === "admin" ? user : null;
-}
 
 export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
   const admin = await requireAdmin();

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -2,16 +2,8 @@
 // Admin-only: list all users with their settings summary.
 
 import { NextResponse } from "next/server";
-import { getUser } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
-
-async function requireAdmin() {
-  const user = await getUser();
-  if (!user) return null;
-  const db = createAdminClient();
-  const { data } = await db.from("user_profiles").select("role").eq("id", user.id).single();
-  return data?.role === "admin" ? user : null;
-}
+import { requireAdmin } from "@/lib/auth";
 
 export async function GET() {
   const admin = await requireAdmin();

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -4,19 +4,8 @@
 
 import { NextResponse, type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { VALID_ATS } from "@/lib/constants";
 import type { ATSType } from "@/lib/types";
-
-const VALID_ATS: ATSType[] = [
-  "greenhouse",
-  "lever",
-  "ashby",
-  "workable",
-  "teamtailor",
-  "breezy",
-  "smartrecruiters",
-  "bamboohr",
-  "jazzhr",
-];
 
 const COUNTRY_FLAGS: Record<string, string> = {
   US: "🇺🇸",

--- a/src/app/api/tracker/[id]/route.ts
+++ b/src/app/api/tracker/[id]/route.ts
@@ -3,18 +3,9 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { getUser } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { VALID_STATUSES } from "@/lib/constants";
 import type { TrackerStatus } from "@/lib/types";
-
 import type { Database } from "@/lib/database.types";
-
-const VALID_STATUSES: TrackerStatus[] = [
-  "applied",
-  "interviewing",
-  "offer",
-  "rejected",
-  "ghosted",
-  "saved",
-];
 
 // ── PATCH /api/tracker/[id] ───────────────────────────────
 

--- a/src/app/api/tracker/route.ts
+++ b/src/app/api/tracker/route.ts
@@ -3,17 +3,9 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { getUser } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { VALID_STATUSES } from "@/lib/constants";
 import type { TrackerStatus, TrackerJobSnapshot } from "@/lib/types";
 import type { Json } from "@/lib/database.types";
-
-const VALID_STATUSES: TrackerStatus[] = [
-  "applied",
-  "interviewing",
-  "offer",
-  "rejected",
-  "ghosted",
-  "saved",
-];
 
 // ── GET /api/tracker ──────────────────────────────────────
 

--- a/src/components/settings/SettingsForm.tsx
+++ b/src/components/settings/SettingsForm.tsx
@@ -2,10 +2,11 @@
 // src/components/settings/SettingsForm.tsx
 
 import { useState, useEffect } from "react";
+import type { ResolvedSettings, UserSettingsRow } from "@/lib/types";
 
 interface SettingsData {
-  resolved: Record<string, unknown>;
-  raw: Record<string, unknown> | null;
+  resolved: ResolvedSettings;
+  raw: UserSettingsRow | null;
   profile: { email: string; has_gemini_key: boolean; onboarding_complete: boolean };
 }
 
@@ -41,25 +42,23 @@ export default function SettingsForm() {
       if (json.ok) {
         const d: SettingsData = json.data;
         setData(d);
-        const r = d.resolved as Record<string, unknown>;
-        const raw = d.raw as Record<string, unknown> | null;
-        setUsesDefaults((raw?.uses_defaults as boolean) ?? true);
-        setExpertSkills(((r.expert_skills ?? []) as string[]).join(", "));
-        setSecSkills(((r.secondary_skills ?? []) as string[]).join(", "));
-        setJobAgeDays((r.job_age_days as number) ?? 7);
-        setVisa((r.pipeline_visa as boolean) ?? true);
-        setLocal((r.pipeline_local as boolean) ?? true);
-        setGlobal((r.pipeline_global as boolean) ?? true);
-        setAllowMid((r.seniority_allow_mid as boolean) ?? false);
-        setEmailAlerts((r.email_alerts_enabled as boolean) ?? true);
-        setPrompt((r.gemini_filter_prompt as string) ?? "");
-        setExcludedKeywords(((r.excluded_keywords ?? []) as string[]).join(", "));
-        setBlacklistedLocations(((r.blacklisted_locations ?? []) as string[]).join(", "));
-        setRequiredKeywords(((r.required_keywords ?? []) as string[]).join(", "));
-        const w = r.scoring_weights as { skill: number; recency: number } | undefined;
-        if (w) {
-          setSkillWeight(Math.round(w.skill * 100));
-          setRecencyWeight(Math.round(w.recency * 100));
+        const r = d.resolved;
+        setUsesDefaults(d.raw?.uses_defaults ?? true);
+        setExpertSkills((r.expert_skills ?? []).join(", "));
+        setSecSkills((r.secondary_skills ?? []).join(", "));
+        setJobAgeDays(r.job_age_days ?? 7);
+        setVisa(r.pipeline_visa ?? true);
+        setLocal(r.pipeline_local ?? true);
+        setGlobal(r.pipeline_global ?? true);
+        setAllowMid(r.seniority_allow_mid ?? false);
+        setEmailAlerts(r.email_alerts_enabled ?? true);
+        setPrompt(r.gemini_filter_prompt ?? "");
+        setExcludedKeywords((r.excluded_keywords ?? []).join(", "));
+        setBlacklistedLocations((r.blacklisted_locations ?? []).join(", "));
+        setRequiredKeywords((r.required_keywords ?? []).join(", "));
+        if (r.scoring_weights) {
+          setSkillWeight(Math.round(r.scoring_weights.skill * 100));
+          setRecencyWeight(Math.round(r.scoring_weights.recency * 100));
         }
       }
       setLoading(false);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,21 @@
+// src/lib/auth.ts
+// Shared auth helpers for API route handlers.
+
+import { getUser } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import type { User } from "@supabase/supabase-js";
+
+/**
+ * Returns the authenticated user if they have role='admin', otherwise null.
+ * Use at the top of every admin API route handler.
+ *
+ *   const admin = await requireAdmin();
+ *   if (!admin) return NextResponse.json({ ok: false, error: "Forbidden" }, { status: 403 });
+ */
+export async function requireAdmin(): Promise<User | null> {
+  const user = await getUser();
+  if (!user) return null;
+  const db = createAdminClient();
+  const { data } = await db.from("user_profiles").select("role").eq("id", user.id).single();
+  return data?.role === "admin" ? user : null;
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,6 +1,29 @@
 // src/lib/constants.ts
 
+import type { ATSType, TrackerStatus } from "./types";
+
 // ── Shared Constants ─────────────────────────────────────────────────────
+
+export const VALID_ATS: ATSType[] = [
+  "greenhouse",
+  "lever",
+  "ashby",
+  "workable",
+  "teamtailor",
+  "breezy",
+  "smartrecruiters",
+  "bamboohr",
+  "jazzhr",
+];
+
+export const VALID_STATUSES: TrackerStatus[] = [
+  "applied",
+  "interviewing",
+  "offer",
+  "rejected",
+  "ghosted",
+  "saved",
+];
 export const COUNTRY_MAP: Record<string, { name: string; flag: string }> = {
   ireland: { name: "Ireland", flag: "🇮🇪" },
   germany: { name: "Germany", flag: "🇩🇪" },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -235,6 +235,42 @@ export interface ATSTestResult {
   tested_at: string;
 }
 
+export type ATSSubmissionStatus = "pending" | "approved" | "rejected";
+
+/** Row from public.ats_submissions */
+export interface ATSSubmission {
+  id: string;
+  company_name: string;
+  ats_type: ATSType;
+  slug: string;
+  country: string;
+  country_flag: string;
+  city: string | null;
+  pipeline_visa: boolean;
+  pipeline_local: boolean;
+  pipeline_global: boolean;
+  submitter_email: string | null;
+  status: ATSSubmissionStatus;
+  test_result: ATSTestResult | null;
+  submitted_at: string;
+  reviewed_at: string | null;
+  reviewed_by: string | null;
+}
+
+// ── Admin ────────────────────────────────────────────────────
+
+/** Shape returned by GET /api/admin/users — user_profiles joined with user_settings */
+export interface AdminUserListItem {
+  id: string;
+  email: string;
+  role: "admin" | "user";
+  onboarding_complete: boolean;
+  is_active: boolean;
+  created_at: string;
+  last_active_at: string | null;
+  user_settings: { uses_defaults: boolean } | null;
+}
+
 // ── Cron ────────────────────────────────────────────────────
 
 export interface CronRunResult {


### PR DESCRIPTION


- Add ATSSubmission, ATSSubmissionStatus, AdminUserListItem to lib/types.ts (ats_submissions had no shared type despite being used in 3 route files; admin user list join shape was inline-only)

- Add VALID_ATS, VALID_STATUSES to lib/constants.ts (was copy-pasted verbatim into 3 and 2 route files respectively)

- Extract requireAdmin() to lib/auth.ts (was byte-for-byte identical across all 8 admin route files; authorization boundary should not have 8 maintenance points)

- Update all 8 admin routes to import requireAdmin from lib/auth
- Update admin/companies, admin/companies/[id], submit to import VALID_ATS from lib/constants
- Update tracker, tracker/[id] to import VALID_STATUSES from lib/constants

- Fix SettingsForm.SettingsData types: resolved Record<string,unknown> → ResolvedSettings, raw Record<string,unknown>|null → UserSettingsRow|null; remove all manual casts in useEffect

tsc: clean · vitest: 65/65 · next build: success