### PR TITLE
refactor(phase4): migrate user-scoped routes off service-role client

### DIFF
--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -7,7 +7,7 @@
 // First load after a cron run takes 10-15s; all subsequent opens are instant.
 
 import { NextResponse } from "next/server";
-import { getUser } from "@/lib/supabase/server";
+import { getUser, createServerClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { resolveUserSettings } from "@/lib/settings";
 import { filterJobsWithGemini } from "@/lib/gemini";
@@ -25,7 +25,11 @@ export async function GET() {
     return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
   }
 
-  const db = createAdminClient();
+  const db = createServerClient();
+  // raw_jobs and app_config are global, not user-owned — RLS wasn't
+  // checked/granted for them, so they stay on the service-role client.
+  // See docs/plans/2026-06-23-phase4-data-access-migration.md, task 8.
+  const adminDb = createAdminClient();
 
   // Update last_active_at (fire and forget)
   db.from("user_profiles")
@@ -93,7 +97,7 @@ export async function GET() {
   if (settings.pipeline_local) enabledModes.push("local");
   if (settings.pipeline_global) enabledModes.push("global");
 
-  const { data: rawJobsData, error: rawError } = await db
+  const { data: rawJobsData, error: rawError } = await adminDb
     .from("raw_jobs")
     .select("*")
     .in("mode", enabledModes)
@@ -142,7 +146,7 @@ export async function GET() {
   };
 
   // ── Step 7: Write cache ──────────────────────────────────────
-  const { data: appConfig } = await db
+  const { data: appConfig } = await adminDb
     .from("app_config")
     .select("last_cron_at")
     .eq("id", 1)

--- a/src/app/api/jobs/[id]/route.ts
+++ b/src/app/api/jobs/[id]/route.ts
@@ -6,8 +6,7 @@
 // settings that may have changed since.
 
 import { NextResponse, type NextRequest } from "next/server";
-import { getUser } from "@/lib/supabase/server";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { getUser, createServerClient } from "@/lib/supabase/server";
 import type { ScoredJob } from "@/lib/types";
 
 export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
@@ -16,7 +15,7 @@ export async function GET(_req: NextRequest, { params }: { params: { id: string 
     return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
   }
 
-  const db = createAdminClient();
+  const db = createServerClient();
 
   const { data: cache } = await db
     .from("user_jobs_cache")

--- a/src/app/api/salary/route.ts
+++ b/src/app/api/salary/route.ts
@@ -1,8 +1,7 @@
 // src/app/api/salary/route.ts
 
 import { NextResponse, type NextRequest } from "next/server";
-import { getUser } from "@/lib/supabase/server";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { getUser, createServerClient } from "@/lib/supabase/server";
 import type {
   SalaryAggregate,
   SalaryCurrency,
@@ -21,7 +20,7 @@ export async function GET(request: NextRequest) {
   const roleFilter = url.searchParams.get("role");
   const pipelineFilter = url.searchParams.get("pipeline");
 
-  const db = createAdminClient();
+  const db = createServerClient();
 
   let query = db
     .from("salary_reports")
@@ -76,7 +75,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ ok: false, error: "Invalid currency" }, { status: 400 });
   }
 
-  const db = createAdminClient();
+  const db = createServerClient();
   const now = new Date().toISOString();
 
   const { data, error } = await db

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,8 +1,7 @@
 // src/app/api/settings/route.ts
 
 import { NextResponse, type NextRequest } from "next/server";
-import { getUser } from "@/lib/supabase/server";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { getUser, createServerClient } from "@/lib/supabase/server";
 import { resolveUserSettings, saveUserSettings } from "@/lib/settings";
 
 // ── GET /api/settings ─────────────────────────────────────
@@ -11,7 +10,7 @@ export async function GET() {
   const user = await getUser();
   if (!user) return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
 
-  const [resolved, db] = [await resolveUserSettings(user.id), createAdminClient()];
+  const [resolved, db] = [await resolveUserSettings(user.id), createServerClient()];
 
   // Also return the raw user settings row (for the form's initial state)
   const { data: rawSettings } = await db
@@ -56,7 +55,7 @@ export async function PATCH(request: NextRequest) {
   // Strip any attempt to set role (security guard — role is immutable from app layer)
   delete body.role;
 
-  const db = createAdminClient();
+  const db = createServerClient();
 
   // Handle gemini_api_key separately (stored in user_profiles, not user_settings)
   if ("gemini_api_key" in body) {

--- a/src/app/api/strategy/route.ts
+++ b/src/app/api/strategy/route.ts
@@ -1,8 +1,7 @@
 // src/app/api/strategy/route.ts
 
 import { NextResponse, type NextRequest } from "next/server";
-import { getUser } from "@/lib/supabase/server";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { getUser, createServerClient } from "@/lib/supabase/server";
 import { generateApplicationStrategy } from "@/lib/gemini";
 import { resolveUserSettings } from "@/lib/settings";
 
@@ -26,7 +25,7 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const db = createAdminClient();
+  const db = createServerClient();
   const { data: profile } = await db
     .from("user_profiles")
     .select("gemini_api_key")

--- a/src/app/api/tracker/[id]/route.ts
+++ b/src/app/api/tracker/[id]/route.ts
@@ -1,8 +1,7 @@
 // src/app/api/tracker/[id]/route.ts
 
 import { NextResponse, type NextRequest } from "next/server";
-import { getUser } from "@/lib/supabase/server";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { getUser, createServerClient } from "@/lib/supabase/server";
 import { VALID_STATUSES } from "@/lib/constants";
 import type { TrackerStatus } from "@/lib/types";
 import type { Database } from "@/lib/database.types";
@@ -20,7 +19,7 @@ export async function PATCH(request: NextRequest, { params }: { params: { id: st
     return NextResponse.json({ ok: false, error: "Invalid JSON" }, { status: 400 });
   }
 
-  const db = createAdminClient();
+  const db = createServerClient();
   const now = new Date().toISOString();
 
   const patch: Database["public"]["Tables"]["tracker_entries"]["Update"] = { updated_at: now };
@@ -52,7 +51,7 @@ export async function DELETE(_request: NextRequest, { params }: { params: { id: 
   const user = await getUser();
   if (!user) return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
 
-  const db = createAdminClient();
+  const db = createServerClient();
   const { error } = await db
     .from("tracker_entries")
     .delete()

--- a/src/app/api/tracker/route.ts
+++ b/src/app/api/tracker/route.ts
@@ -1,8 +1,7 @@
 // src/app/api/tracker/route.ts
 
 import { NextResponse, type NextRequest } from "next/server";
-import { getUser } from "@/lib/supabase/server";
-import { createAdminClient } from "@/lib/supabase/admin";
+import { getUser, createServerClient } from "@/lib/supabase/server";
 import { VALID_STATUSES } from "@/lib/constants";
 import type { TrackerStatus, TrackerJobSnapshot } from "@/lib/types";
 import type { Json } from "@/lib/database.types";
@@ -13,7 +12,7 @@ export async function GET() {
   const user = await getUser();
   if (!user) return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
 
-  const db = createAdminClient();
+  const db = createServerClient();
   const { data, error } = await db
     .from("tracker_entries")
     .select("*")
@@ -56,7 +55,7 @@ export async function POST(request: NextRequest) {
     ? (body.status as TrackerStatus)
     : "saved";
 
-  const db = createAdminClient();
+  const db = createServerClient();
   const now = new Date().toISOString();
 
   const { data, error } = await db

--- a/src/lib/__tests__/settings.test.ts
+++ b/src/lib/__tests__/settings.test.ts
@@ -2,19 +2,35 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // We test the private mergeWithDefaults logic by testing resolveUserSettings
-// with a mocked admin client. The key behaviour to verify:
+// with mocked Supabase clients. The key behaviour to verify:
 //   1. uses_defaults = true  → all fields come from defaults
 //   2. uses_defaults = false → per-field: user value if non-null, else default
 //   3. Weights are normalised if they don't sum to 1
 
-// ── Mock Supabase admin client ────────────────────────────────
+// ── Mock Supabase clients ──────────────────────────────────────
+// getDefaultSettings() reads default_settings via the service-role client
+// (global config, not user-owned). getUserSettingsRow()/saveUserSettings()
+// read/write user_settings via the auth-aware client (RLS own-row policy).
+// See docs/plans/2026-06-23-phase4-data-access-migration.md, task 7.
 
 const mockAdminDb = {
   from: vi.fn(),
 };
 
+const mockServerDb = {
+  from: vi.fn(),
+};
+
 vi.mock("../supabase/admin", () => ({
   createAdminClient: () => mockAdminDb,
+}));
+
+vi.mock("../supabase/server", () => ({
+  createServerClient: () => mockServerDb,
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: () => ({ getAll: () => [], set: () => {} }),
 }));
 
 // Helper to create a mock Supabase query chain
@@ -63,11 +79,12 @@ describe("resolveUserSettings", () => {
     // User settings query — row says uses_defaults = true
     const userQuery = mockQuery({ user_id: "u1", uses_defaults: true, expert_skills: null });
 
-    mockAdminDb.from.mockImplementation((table: string) => {
-      if (table === "default_settings") return defaultQuery;
-      if (table === "user_settings") return userQuery;
-      return mockQuery(null, { message: "unknown table" });
-    });
+    mockAdminDb.from.mockImplementation((table: string) =>
+      table === "default_settings" ? defaultQuery : mockQuery(null, { message: "unknown table" }),
+    );
+    mockServerDb.from.mockImplementation((table: string) =>
+      table === "user_settings" ? userQuery : mockQuery(null, { message: "unknown table" }),
+    );
 
     const { resolveUserSettings } = await import("../settings");
     const result = await resolveUserSettings("u1");
@@ -97,11 +114,12 @@ describe("resolveUserSettings", () => {
     const defaultQuery = mockQuery(DEFAULT_ROW);
     const userQuery = mockQuery(userSettingsRow);
 
-    mockAdminDb.from.mockImplementation((table: string) => {
-      if (table === "default_settings") return defaultQuery;
-      if (table === "user_settings") return userQuery;
-      return mockQuery(null);
-    });
+    mockAdminDb.from.mockImplementation((table: string) =>
+      table === "default_settings" ? defaultQuery : mockQuery(null),
+    );
+    mockServerDb.from.mockImplementation((table: string) =>
+      table === "user_settings" ? userQuery : mockQuery(null),
+    );
 
     const { resolveUserSettings } = await import("../settings");
     const result = await resolveUserSettings("u2");
@@ -138,11 +156,12 @@ describe("resolveUserSettings", () => {
     const defaultQuery = mockQuery(DEFAULT_ROW);
     const userQuery = mockQuery(userWithBadWeights);
 
-    mockAdminDb.from.mockImplementation((table: string) => {
-      if (table === "default_settings") return defaultQuery;
-      if (table === "user_settings") return userQuery;
-      return mockQuery(null);
-    });
+    mockAdminDb.from.mockImplementation((table: string) =>
+      table === "default_settings" ? defaultQuery : mockQuery(null),
+    );
+    mockServerDb.from.mockImplementation((table: string) =>
+      table === "user_settings" ? userQuery : mockQuery(null),
+    );
 
     const { resolveUserSettings } = await import("../settings");
     const result = await resolveUserSettings("u3");
@@ -158,11 +177,12 @@ describe("resolveUserSettings", () => {
     const defaultQuery = mockQuery(null, { message: "no row" });
     const userQuery = mockQuery(null, { message: "no row" });
 
-    mockAdminDb.from.mockImplementation((table: string) => {
-      if (table === "default_settings") return defaultQuery;
-      if (table === "user_settings") return userQuery;
-      return mockQuery(null);
-    });
+    mockAdminDb.from.mockImplementation((table: string) =>
+      table === "default_settings" ? defaultQuery : mockQuery(null),
+    );
+    mockServerDb.from.mockImplementation((table: string) =>
+      table === "user_settings" ? userQuery : mockQuery(null),
+    );
 
     const { resolveUserSettings } = await import("../settings");
     const result = await resolveUserSettings("u4");
@@ -180,7 +200,7 @@ describe("resolveUserSettings", () => {
       upsert: upsertMock,
     };
 
-    mockAdminDb.from.mockReturnValue(upsertChain);
+    mockServerDb.from.mockReturnValue(upsertChain);
 
     const { saveUserSettings } = await import("../settings");
     await saveUserSettings("u5", {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -4,6 +4,7 @@
 // If uses_defaults = true, returns defaults directly (fast path).
 
 import { createAdminClient } from "./supabase/admin";
+import { createServerClient } from "./supabase/server";
 import type { DefaultSettings, UserSettingsRow, ResolvedSettings, ScoringWeights } from "./types";
 
 const FALLBACK_PROMPT = `You are a job filter for a Senior React/Next.js engineer.
@@ -162,7 +163,7 @@ export async function getDefaultSettings(): Promise<DefaultSettings> {
 
 /** Fetch user_settings row. Returns null if the row doesn't exist. */
 async function getUserSettingsRow(userId: string): Promise<UserSettingsRow | null> {
-  const db = createAdminClient();
+  const db = createServerClient();
   const { data, error } = await db.from("user_settings").select("*").eq("user_id", userId).single();
 
   if (error) return null;
@@ -267,7 +268,7 @@ export async function saveUserSettings(
   userId: string,
   patch: Partial<Omit<UserSettingsRow, "user_id" | "updated_at">>,
 ): Promise<void> {
-  const db = createAdminClient();
+  const db = createServerClient();
 
   // Strip anything that isn't a settings field
   const safe: Record<string, unknown> = { updated_at: new Date().toISOString() };


### PR DESCRIPTION
Switches salary, strategy, tracker, tracker/[id], jobs/[id], settings, and the user-owned parts of dashboard + lib/settings.ts from createAdminClient() to createServerClient(), now that RLS is confirmed enabled with working own-row policies on user_jobs_cache, user_settings, user_profiles, tracker_entries, and salary_reports.

Two deliberate exceptions, not oversights:
- raw_jobs/app_config (dashboard route) and default_settings (lib/settings.ts) stay on the service-role client — global/cron-managed data, not user-owned, not covered by the RLS check.
- submit/route.ts is excluded entirely — it's an unauthenticated public endpoint by design (company/HR submissions), so it never had a session to scope RLS to in the first place. Migrating it would have broken anonymous submissions, not fixed a bypass.

Updated src/lib/__tests__/settings.test.ts to mock both clients separately and stub next/headers cookies(), since getUserSettingsRow/saveUserSettings now go through the cookie-based client.

Plan: docs/plans/2026-06-23-phase4-data-access-migration.md

Validation: tsc --noEmit clean, eslint clean, 65/65 vitest passing, next build successful (30/30 routes).