### PR TITLE
fix(cleanup): phase5 error-handling leftovers + non-blocking items & Fix: gemini filteration and optional gemini key in onboardinng

### DIFF
--- a/docs/plans/2026-06-24-bug2-boilerplate-keyword-gate.md
+++ b/docs/plans/2026-06-24-bug2-boilerplate-keyword-gate.md
@@ -1,0 +1,109 @@
+# Plan: Boilerplate-aware keyword/skill matching (Bug 2, gemini-filter-audit.md)
+
+**Scope:** Small, well-understood. 2 files (1 source + its test file).
+
+## Verification (done, outside this codebase)
+
+Ran the recommended SQL against live `raw_jobs` for the 6 non-engineering
+Vercel postings (Account Executive, Manager Commercial Sales, Partner
+Operations Lead, People Operations Analyst, Senior HRBP, Senior Partner
+Manager AWS) plus the 1 real engineering posting (Software Engineer, eve).
+
+**Confirmed:** every single one of the 7 postings opens with an identical
+`<div class="content-intro">About Vercel: ... As the team behind Next.js,
+v0, and AI SDK...</div>` paragraph. Stripped to plain text this is ~788
+characters, and "Next.js" sits at character index ~190 — comfortably inside
+any reasonable "intro" window. For the 6 non-engineering roles, that's the
+_only_ place "next.js"/"react" appears anywhere in the 3000-char stored
+description — there is no second, role-specific mention. For the real
+engineering role, "Next.js" is mentioned a second time inside the actual
+"About the role" section, well past the intro.
+
+This confirms the working hypothesis exactly: the required-keywords and
+skill-match gates are matching company boilerplate, not job requirements,
+for every non-engineering role at a company whose own product happens to be
+in the user's stack.
+
+## Decision
+
+Implement Option B from the original brief: require a keyword/skill match
+that occurs **after** a boilerplate-prone opening window, **or** two or
+more distinct keywords/skills matched anywhere (breadth). Short texts (at
+or under the window size) are exempt from the position check entirely —
+there's no room for a real "intro vs. body" split, so a single early match
+is trusted exactly as before (this keeps every existing short-fixture test
+passing unchanged).
+
+**Window size: 600 characters.** The confirmed Vercel intro is ~788 chars
+with its only match at ~190 — well inside 600. The original brief suggested
+300–500; 600 is chosen with a little extra margin since real "About
+[Company]" paragraphs run longer than the shortest case, and the cost of a
+too-small window (missing a genuine intro) is worse than the cost of a
+too-large one (a few extra characters of real requirements text rarely
+contain the _only_ keyword mention for an actually-relevant role).
+
+**Known limitation, accepted deliberately:** a posting structured with no
+"About us" intro at all, where the single real requirement happens to
+sit within the first 600 characters, will now fail this gate unless a
+second distinct keyword/skill also matches. This is the misfire risk Option
+A/B always carried (see the original brief). It's accepted because: (a)
+Bug 1 already restored Gemini as a real downstream judgment, so a
+boundary-case false reject at this pre-filter stage isn't necessarily a
+fully lost job — it just means this particular pre-filter, which the brief
+itself frames as "a cheap, deliberately loose recall-favoring pre-filter,"
+is now slightly less loose in one specific, previously-broken way. Revisit
+if real-world false negatives turn up.
+
+## Tasks
+
+### 1. `src/lib/scoring.ts`
+
+- New module constant `BOILERPLATE_WINDOW_CHARS = 600` near the top, with
+  the reasoning above in a comment.
+- New private helper `wordBoundaryPattern(word: string): string` — factors
+  out the existing `escaped = word.replace(...).replace(...)` logic shared
+  by the keyword-matching call sites (kept local to this concern; the
+  pre-existing `excluded_keywords`/`blacklisted_locations` inline logic in
+  `passesSettingsGate` is untouched — not in scope for this bug).
+- New exported function `hasMeaningfulKeywordMatch(text: string, keywords: string[]): boolean`:
+  - If `text.length <= BOILERPLATE_WINDOW_CHARS`: return true if any
+    keyword matches anywhere (old behavior, unchanged).
+  - Else: scan each keyword globally for every occurrence index. A keyword
+    "counts" if it has at least one occurrence. Track (a) whether _any_
+    occurrence of _any_ keyword falls at index `>= BOILERPLATE_WINDOW_CHARS`,
+    and (b) how many distinct keywords matched at all. Return
+    `matchOutsideWindow || distinctMatchCount >= 2`.
+- `passesSettingsGate`, step 3 (required keywords): replace the
+  `techKeywords.some(...)` single-match check with
+  `hasMeaningfulKeywordMatch(textCombined, techKeywords)`.
+- `passesSettingsGate`, step 5 (skill match): replace the
+  `expertMatched.length === 0 && secondaryMatched.length === 0` check with
+  `!hasMeaningfulKeywordMatch(job.description, [...settings.expert_skills, ...settings.secondary_skills])`
+  for the early-return-false condition. (`matchSkills`/`computeSkillMatchScore`
+  elsewhere — used for the actual `matched_skills` list and scoring — are
+  untouched; this only changes the pass/fail gate.)
+
+### 2. `src/lib/__tests__/scoring.test.ts`
+
+Add to the `passesSettingsGate` describe block:
+
+- A test reproducing the confirmed Vercel pattern: a long (>600 char)
+  description whose only required-keyword/skill mention is a company-intro
+  paragraph in the first ~200 characters, with no second mention anywhere
+  else → `passesSettingsGate` returns `false`.
+- A test for the same long intro pattern but where the real engineering
+  section _also_ mentions the keyword past the 600-char mark → returns
+  `true`.
+- A test confirming two distinct keyword/skill matches anywhere (even both
+  inside the window) still passes — the breadth escape hatch.
+- Confirm (no new test needed, just don't break) the existing short-fixture
+  tests in the same describe block still pass unchanged, since their
+  descriptions are well under 600 chars.
+
+## Acceptance criteria
+
+- `tsc --noEmit` clean, `eslint --fix` clean, all vitest passing (new +
+  existing), `next build` successful.
+- All 7 existing `passesSettingsGate` tests pass unchanged.
+- New tests confirm the Vercel false-positive pattern is rejected and the
+  genuine-match-past-the-intro pattern is accepted.

--- a/docs/plans/2026-06-24-bug3-truncation-limits.md
+++ b/docs/plans/2026-06-24-bug3-truncation-limits.md
@@ -1,0 +1,75 @@
+# Plan: Deliberate truncation limits (Bug 3, gemini-filter-audit.md)
+
+**Scope:** Tiny. 2 one-line changes, each a constant.
+
+## Verification (done, outside this codebase)
+
+Ran the recommended query against live `raw_jobs`:
+
+```sql
+select length(description) from raw_jobs order by length(description) desc limit 20;
+```
+
+Result: **all 20 of the longest descriptions are exactly 3000 characters**
+— i.e. every one of them hit the ingestion ceiling and was cut off, not
+coincidentally landing at exactly 3000. This confirms the truncation is
+actively biting in practice, not just a theoretical concern.
+
+## Decision
+
+Raise both limits, deliberately, with the two now chosen to relate to each
+other instead of having independently evolved:
+
+- **Ingestion ceiling** (`ats-utils.ts` `processJobs`): **3000 → 6000
+  characters.** This is the absolute ceiling on what's ever stored in
+  `raw_jobs` and what the settings-gate (`passesSettingsGate`, including
+  Bug 2's fix) searches against. Doubling it costs effectively nothing —
+  it's a `TEXT` column, not an LLM call — and gives real long-form JDs
+  (intro → responsibilities → requirements → benefits → EEO, often
+  3000–5000+ characters per the original brief's own estimate) enough room
+  for the requirements section to actually be stored, rather than reliably
+  truncated away.
+- **Gemini-call truncation** (`gemini.ts` `filterBatch`): **1200 → 3000
+  characters.** This now exactly matches the _old_ ingestion ceiling, so
+  Gemini at minimum sees everything that used to be the entire stored
+  description. It does not match the _new_ 6000-char ingestion ceiling —
+  that's a deliberate, accepted tradeoff: `BATCH_SIZE` is 30 jobs per
+  Gemini call, so this is a 2.5x increase in prompt size per call (1200→3000
+  chars × 30 jobs), already a meaningful added token/cost burden. Matching
+  the full 6000-char ceiling would mean 5x the description tokens per call
+  versus today. 3000 is chosen as the number explicitly suggested as a
+  reasonable middle ground in the original brief ("maybe 2500–3000, to at
+  least match what's actually stored" — referring to the old 3000 ceiling),
+  while the _settings gate_ (cheap, no API cost) gets the full benefit of
+  the larger 6000-char ingestion window.
+
+**Why not match them exactly:** the settings gate's cost is effectively
+free (a few extra regex scans over already-fetched text); Gemini's cost
+scales directly with tokens sent. It's reasonable for the free pre-filter
+to see more text than the paid filter, especially since Bug 1's idx-based
+matching and Bug 2's boilerplate-aware matching already make the cheap
+pre-filter meaningfully more accurate on its own.
+
+## Tasks
+
+### 1. `src/lib/sources/ats-utils.ts`
+
+- `processJobs`: `description: r.description.slice(0, 3000)` →
+  `description: r.description.slice(0, 6000)`, with the reasoning above
+  added as a comment.
+
+### 2. `src/lib/gemini.ts`
+
+- `filterBatch`: `description: j.description.slice(0, 1200)` →
+  `description: j.description.slice(0, 3000)`, with a comment noting this
+  is deliberately less than the 6000-char ingestion ceiling — see
+  `processJobs`'s comment for the cost/accuracy tradeoff.
+
+## Acceptance criteria
+
+- `tsc --noEmit` clean, `eslint --fix` clean, all vitest passing, `next build`
+  successful.
+- No test currently asserts on these exact numeric limits (checked); none
+  expected to break.
+- Both limits are now deliberate, cross-referenced choices instead of two
+  independently-evolved magic numbers.

--- a/docs/plans/2026-06-24-bug4-bamboohr-detail-fetch.md
+++ b/docs/plans/2026-06-24-bug4-bamboohr-detail-fetch.md
@@ -1,0 +1,72 @@
+# Plan: BambooHR detail fetch for descriptions (Bug 4, gemini-filter-audit.md)
+
+**Scope:** Small, isolated. 2 files (1 source + its type definitions),
+narrow blast radius (only BambooHR-hosted companies).
+
+## Verification (done, outside this codebase)
+
+Confirmed the live shape of both BambooHR endpoints against a real company
+(`instabug.bamboohr.com`):
+
+- List endpoint (`/careers/list`) — already used by `fetchBambooHR` —
+  confirmed to return only `{ result: [{ id, jobOpeningName, departmentId,
+... }] }`, no description field. Matches existing code's assumption.
+- Detail endpoint (`/careers/{id}/detail`) — confirmed shape:
+  `{ result: { jobOpening: { description: "<p>...</p>", ... } } }`. The
+  description is real HTML, same as every other ATS's detail/list response
+  (`stripHtml` applies cleanly).
+
+This confirms the fix direction in the original brief without guessing: add
+a per-job detail fetch mirroring `fetchWorkable`'s existing pattern.
+
+## Tasks
+
+### 1. `src/types/api.ts`
+
+- New `BambooDetail` interface for the confirmed detail-endpoint shape:
+  `{ result?: { jobOpening?: { description?: string } } }`. Minimal — only
+  the field this fetcher actually reads.
+
+### 2. `src/lib/sources/ats-utils.ts`
+
+- `fetchBambooHR`: after fetching the list, run a `pLimit`-bounded
+  (concurrency 5, same as `fetchWorkable`) detail fetch per job:
+  - `GET https://${c.slug}.bamboohr.com/careers/${r.id}/detail` via the
+    existing `safeFetch` helper (consistent with this fetcher's list call;
+    `fetchWorkable` uses a raw `fetch` instead, but there's no reason to
+    diverge from `safeFetch` here — same timeout/User-Agent handling).
+  - On success, `description: stripHtml(detail.result?.jobOpening?.description ?? "")`.
+  - On any failure (network, non-OK, parse error), fall back to `""` —
+    same fail-open shape as the rest of this fetcher and as
+    `fetchWorkable`'s detail-fetch failure path. A BambooHR detail-fetch
+    hiccup degrades a job back to today's "no description" state rather
+    than breaking the whole fetch run.
+- Not in scope (deliberately): the per-run `console.log` progress line that
+  currently exists only in `fetchWorkable`. That's a separate, already-
+  tracked cleanup item (Phase 7 in the full codebase audit) about deciding
+  whether to add it everywhere or remove it — not something to half-decide
+  as a side effect of this fix.
+
+### 3. Tests
+
+No existing test file mocks `fetch`/`safeFetch` for any of the 9 ATS
+fetchers — `ats-bridge.test.ts` only tests the dispatch layer, with
+`fetchBambooHR` itself mocked out entirely. That's a pre-existing gap
+across all fetchers, not specific to BambooHR, and unlike Bug 1 (which
+explicitly called for a new `gemini.test.ts`), the original brief doesn't
+mandate new tests for this fix. Standing up a `fetch`-mocking convention
+from scratch is a separate, broader decision (it'd set the pattern for all
+9 fetchers) and out of scope for this narrow, low-risk fix. `tsc --noEmit`
+
+- `eslint` + `next build` are the validation gates here, same as the
+  project's other "no behavior risk" changes.
+
+## Acceptance criteria
+
+- `tsc --noEmit` clean, `eslint --fix` clean, all vitest passing, `next build`
+  successful.
+- BambooHR jobs now carry a real description, so `passesSettingsGate`'s
+  required-keywords/skill-match steps (and Gemini) have real content to
+  evaluate instead of title-only text.
+- A failed detail fetch degrades gracefully to today's behavior (empty
+  description), not a dropped job or an unhandled exception.

--- a/docs/plans/2026-06-24-feature2-optional-gemini-key.md
+++ b/docs/plans/2026-06-24-feature2-optional-gemini-key.md
@@ -1,0 +1,89 @@
+# Plan: Optional Gemini key at onboarding (Feature Request 2, gemini-filter-audit.md)
+
+**Approved**, with one explicit modification from the original brief:
+onboarding becomes **one screen instead of two** (the original brief's
+"current 2-step flow" framing is now moot — the key being optional removes
+the reason to gate Step 2 behind Step 1 at all).
+
+**Scope:** Medium. Touches the dashboard route's hard-block logic and a
+full rewrite of the onboarding component. No DB schema change — both
+`gemini_api_key` and `uses_defaults`/`onboarding_complete` already save via
+a single `PATCH /api/settings` call (confirmed in `settings/route.ts`).
+
+## The inconsistency being fixed
+
+Today: no key → hard 422, dashboard never loads. Key present but
+invalid/rate-limited/exhausted → Gemini fails open silently, user sees
+everything. The strictest outcome is reserved for the most-correct user
+behavior (no key, because they haven't gotten one yet); the most lenient
+outcome happens on the path where something's actually wrong. Feature
+Request 1's `gemini_reviewed` indicator now gives every job an honest,
+visible answer to "was this AI-reviewed?" regardless of key presence —
+which removes the only reason the hard block existed.
+
+## Decision
+
+- Missing key → skip Gemini entirely (don't call `filterJobsWithGemini`).
+  Jobs that pass the settings gate go straight to scoring, marked
+  `gemini_pass: true, gemini_reason: null, gemini_reviewed: false` — same
+  shape Bug 1's fail-open path already produces, so Feature Request 1's
+  badge ("⚠ Not AI-reviewed (showing anyway)") shows up for free, no new
+  UI logic needed.
+- Present key → unchanged: run Gemini as today, with Bug 1's fixed
+  matching and Bug 2's fixed pre-filter.
+- Onboarding becomes a single screen: an optional Gemini-key field at the
+  top (skippable — leave blank and continue), with the existing
+  defaults-vs-customize choice immediately below it, also on that same
+  screen. Each of the two choice buttons now does both jobs in one
+  submit: save the key if one was entered, set `uses_defaults` to match
+  the button pressed, and mark `onboarding_complete: true` — all in the
+  single existing `PATCH /api/settings` call. No new step, no progress
+  bar needed since there's only one screen.
+
+## Tasks
+
+### 1. `src/app/api/dashboard/route.ts`
+
+- Remove the `if (!profile?.gemini_api_key) return 422 ...` hard block.
+- Branch step 4: if `profile?.gemini_api_key` is present, call
+  `filterJobsWithGemini` as today. If absent, build the same return shape
+  directly from `afterSettingsFilter` — each job spread with
+  `gemini_pass: true, gemini_reason: null, gemini_reviewed: false` — so
+  step 5 (scoring) runs unchanged either way.
+
+### 2. `src/components/onboarding/OnboardingFlow.tsx`
+
+- Full rewrite: drop the `Step` state machine and progress-bar markup
+  entirely (no longer a multi-step flow).
+- Single screen: optional Gemini key input (label no longer marked
+  required; helper copy explains that without a key, jobs are shown
+  settings-filtered only, with the "not AI-reviewed" badge, and a key can
+  always be added later in Settings), key-format validation only runs if
+  a non-empty key is entered, then the two existing defaults/customize
+  choice buttons immediately below — each calling one combined submit
+  function that saves whatever key (if any) + the chosen `uses_defaults`
+  value + `onboarding_complete: true` in a single `PATCH /api/settings`
+  call, then routes to `/dashboard` or `/settings` respectively (same
+  destinations as today).
+
+### 3. Tests
+
+No existing test file covers `OnboardingFlow.tsx` or the dashboard route's
+key-branching logic directly (checked — `dashboard/route.ts` has no
+dedicated test file, consistent with the rest of the API route layer in
+this codebase, which is validated via `next build` + manual/integration
+testing rather than route-level unit tests). Not introducing a new test
+pattern as a side effect of this change; `tsc --noEmit` + `eslint` +
+`next build` are the validation gates, consistent with how this codebase
+already treats its route handlers and components.
+
+## Acceptance criteria
+
+- `tsc --noEmit` clean, `eslint --fix` clean, all vitest passing, `next build`
+  successful.
+- A user with no Gemini key reaches `/dashboard` and sees settings-filtered
+  jobs, each marked `gemini_reviewed: false` (visible via Feature Request
+  1's badge).
+- A user with a valid key sees the same behavior as before this change.
+- Onboarding is a single screen: key field (optional) + the two
+  defaults/customize choices, no second step.

--- a/docs/plans/2026-06-24-gemini-reviewed-indicator.md
+++ b/docs/plans/2026-06-24-gemini-reviewed-indicator.md
@@ -1,0 +1,102 @@
+# Plan: "Was this job actually AI-reviewed?" indicator (Feature Request 1, gemini-filter-audit.md)
+
+**Scope:** Small, well-understood. 6 files, no DB migration (the field lives
+inside the existing `jobs` JSONB column in `user_jobs_cache`, same as every
+other `ScoredJob` field — no schema change needed).
+
+## Problem
+
+Bug 1's fix made the "Gemini didn't return a decision for this job" case
+loud (a `console.error`) instead of silent, but it's still invisible to the
+user. A job that fails open because Gemini's response was incomplete, or
+because the whole call failed, looks identical in the UI to a job Gemini
+genuinely evaluated and passed. There is currently no way for a user looking
+at the dashboard to tell "Gemini actually looked at this and liked it" apart
+from "Gemini's call had a problem and this slipped through by default."
+
+## Decision
+
+Add a new boolean, `gemini_reviewed`, alongside the existing
+`gemini_pass`/`gemini_reason` fields — additive, not a replacement. `true`
+only when Gemini returned a valid, matched decision for that job's index.
+`false` for both fail-open paths (missing idx in an otherwise-successful
+response, and total batch failure / `gemini-unavailable`). Surface it as a
+small "⚠ Not AI-reviewed (showing anyway)" badge on the dashboard card and
+job detail page when `false`; no visible change when `true` (the existing
+"Gemini: <reason>" line already implies a real review).
+
+## Tasks
+
+### 1. `src/lib/gemini.ts`
+
+- `FilterResult` interface: add `reviewed: boolean`.
+- In `filterBatch`'s decision loop (where `resultMap.set(job.id, {...})` runs
+  for a valid, matched idx): set `reviewed: true`.
+- In the catch block (`gemini-unavailable` fail-open): set `reviewed: false`.
+- In the final "any job not in Gemini's response" fail-open loop: set
+  `reviewed: false`.
+- `filterJobsWithGemini`'s return type: add `gemini_reviewed: boolean` to the
+  returned object shape; read it off `d.reviewed` (default `false` if `d` is
+  somehow undefined, but `filterBatch` always populates every job now so this
+  is just a type-safety fallback, not a new behavior path).
+
+### 2. `src/lib/types.ts`
+
+- `ScoredJob`: add `gemini_reviewed: boolean` next to `gemini_pass`/`gemini_reason`.
+
+### 3. `src/lib/scoring.ts`
+
+- `scoreJob(job, settings, geminiPass = false, geminiReason = null, geminiReviewed = false)`
+  — new 5th param, defaulted so every existing call site without it still
+  compiles and behaves the same (default `false` matches "no real Gemini
+  review happened," which is correct for the no-arg case used in tests).
+- Include `gemini_reviewed: geminiReviewed` in the returned object.
+
+### 4. `src/app/api/dashboard/route.ts`
+
+- Line ~131: `scoreJob(job, settings, job.gemini_pass, job.gemini_reason, job.gemini_reviewed)`.
+
+### 5. `src/components/dashboard/JobCard.tsx`
+
+- In the tags row (next to the mode/visa-sponsorship badges) or directly
+  above the Gemini-reason line in the expanded section: when
+  `!job.gemini_reviewed`, render a small badge —
+  `⚠ Not AI-reviewed (showing anyway)` — styled consistently with the
+  existing tag badges (same `rounded-full px-2 py-0.5 text-[11px]` pattern,
+  amber/warning tone to match the existing bonus-skill amber). When
+  `job.gemini_reviewed` is `true`, no change — existing "Gemini: reason" line
+  in the expanded section is unchanged and sufficient.
+
+### 6. `src/app/job/[id]/page.tsx`
+
+- Same badge, same condition, placed near the existing
+  `{job.gemini_reason && (...)}` block (~line 211): show the not-reviewed
+  badge when `!job.gemini_reviewed`, regardless of whether `gemini_reason`
+  happens to be set (reason is `null` in both fail-open paths today, but the
+  badge's condition is `gemini_reviewed`, not `reason`, to stay correct if
+  that ever changes).
+
+### 7. Tests
+
+- `src/lib/__tests__/gemini.test.ts` — extend existing cases (no new
+  describe block needed, this is additive to what's already covered):
+  - "maps complete responses..." → assert `gemini_reviewed === true` for the
+    matched job.
+  - "fails open and logs loudly when some idx are missing" → assert
+    `gemini_reviewed === false` for job "b" (the missing one).
+  - "falls back to gemini-unavailable" → assert `gemini_reviewed === false`.
+  - "handles malformed/non-JSON responses" → assert `gemini_reviewed === false`.
+- `src/lib/__tests__/scoring.test.ts` — extend the existing
+  "passes gemini_pass and gemini_reason through" test (or add one beside it)
+  to also assert `gemini_reviewed` passes through, and that it defaults to
+  `false` when omitted (covers the dashboard's existing un-migrated cache
+  rows / any call site that doesn't pass it).
+
+## Acceptance criteria
+
+- `tsc --noEmit` clean, `eslint --fix` clean, all vitest passing (updated +
+  existing), `next build` successful.
+- A job whose Gemini decision was genuinely matched shows no new UI change.
+- A job that fails open (missing idx or batch failure) shows the
+  "⚠ Not AI-reviewed (showing anyway)" badge on both the dashboard card and
+  the job detail page.

--- a/src/app/api/cron/route.ts
+++ b/src/app/api/cron/route.ts
@@ -8,6 +8,7 @@
 // happens lazily when a user opens their dashboard ("Lazy C" model).
 
 import { NextResponse, type NextRequest } from "next/server";
+import { catchErrorResponse } from "@/lib/api-errors";
 import { runCronJob } from "@/lib/runner";
 
 function isAuthorized(request: NextRequest): boolean {
@@ -59,8 +60,6 @@ async function handler(request: NextRequest) {
       },
     });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    console.error("[api/cron] Fatal error:", message);
-    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+    return catchErrorResponse("cron", err);
   }
 }

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -85,12 +85,8 @@ export async function GET() {
     db.from("user_profiles").select("gemini_api_key").eq("id", user.id).single(),
   ]);
 
-  if (!profile?.gemini_api_key) {
-    return NextResponse.json(
-      { ok: false, error: "No Gemini API key configured. Please add one in Settings." },
-      { status: 422 },
-    );
-  }
+  // Feature Request 2 (gemini-filter-audit.md): the Gemini key is now
+  // optional — see the Step 4 branch below for what happens without one.
 
   // ── Step 1: Fetch raw jobs for enabled pipelines ─────────────
   const enabledModes: string[] = [];
@@ -119,16 +115,26 @@ export async function GET() {
   const afterSettingsFilter = afterDateFilter.filter((j) => passesSettingsGate(j, settings));
 
   // ── Step 4: Gemini filter ────────────────────────────────────
-  const geminiFiltered = await filterJobsWithGemini(
-    profile.gemini_api_key,
-    afterSettingsFilter,
-    settings,
-  );
+  // No key -> skip Gemini entirely rather than hard-blocking the whole
+  // dashboard (the old behavior). An invalid/exhausted key already failed
+  // open silently and showed everything anyway, so the strictest outcome
+  // was backwards: reserved for the one case where the user did
+  // everything right. Missing-key jobs get the same fail-open shape Bug
+  // 1's matching already produces, so Feature Request 1's "Not
+  // AI-reviewed" badge covers this for free.
+  const geminiFiltered = profile?.gemini_api_key
+    ? await filterJobsWithGemini(profile.gemini_api_key, afterSettingsFilter, settings)
+    : afterSettingsFilter.map((j) => ({
+        ...j,
+        gemini_pass: true,
+        gemini_reason: null,
+        gemini_reviewed: false,
+      }));
 
   // ── Step 5: Score ────────────────────────────────────────────
   const scoredJobs: ScoredJob[] = [];
   for (const job of geminiFiltered) {
-    const scored = scoreJob(job, settings, job.gemini_pass, job.gemini_reason);
+    const scored = scoreJob(job, settings, job.gemini_pass, job.gemini_reason, job.gemini_reviewed);
     if (scored && scored.total_score > 0) {
       scoredJobs.push(scored);
     }

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -2,7 +2,7 @@
 
 import { NextResponse, type NextRequest } from "next/server";
 import { getUser, createServerClient } from "@/lib/supabase/server";
-import { dbErrorResponse } from "@/lib/api-errors";
+import { dbErrorResponse, catchErrorResponse } from "@/lib/api-errors";
 import { resolveUserSettings, saveUserSettings } from "@/lib/settings";
 
 // ── GET /api/settings ─────────────────────────────────────
@@ -86,8 +86,7 @@ export async function PATCH(request: NextRequest) {
     try {
       await saveUserSettings(user.id, body as Parameters<typeof saveUserSettings>[1]);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      return NextResponse.json({ ok: false, error: message }, { status: 500 });
+      return catchErrorResponse("settings:PATCH", err);
     }
   }
 

--- a/src/app/api/strategy/route.ts
+++ b/src/app/api/strategy/route.ts
@@ -4,6 +4,7 @@ import { NextResponse, type NextRequest } from "next/server";
 import { getUser, createServerClient } from "@/lib/supabase/server";
 import { generateApplicationStrategy } from "@/lib/gemini";
 import { resolveUserSettings } from "@/lib/settings";
+import { catchErrorResponse } from "@/lib/api-errors";
 
 export async function POST(request: NextRequest) {
   const user = await getUser();
@@ -43,7 +44,6 @@ export async function POST(request: NextRequest) {
     const result = await generateApplicationStrategy(profile.gemini_api_key, body.job, userSkills);
     return NextResponse.json({ ok: true, data: result });
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return NextResponse.json({ ok: false, error: message }, { status: 500 });
+    return catchErrorResponse("strategy:POST", err);
   }
 }

--- a/src/app/api/submit/route.ts
+++ b/src/app/api/submit/route.ts
@@ -5,38 +5,41 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { dbErrorResponse } from "@/lib/api-errors";
-import { VALID_ATS } from "@/lib/constants";
+import { VALID_ATS, COUNTRY_FLAGS } from "@/lib/constants";
 import type { ATSType } from "@/lib/types";
 
-const COUNTRY_FLAGS: Record<string, string> = {
-  US: "🇺🇸",
-  UK: "🇬🇧",
-  GB: "🇬🇧",
-  DE: "🇩🇪",
-  FR: "🇫🇷",
-  EG: "🇪🇬",
-  NL: "🇳🇱",
-  ES: "🇪🇸",
-  IT: "🇮🇹",
-  PL: "🇵🇱",
-  CA: "🇨🇦",
-  AU: "🇦🇺",
-  SE: "🇸🇪",
-  NO: "🇳🇴",
-  DK: "🇩🇰",
-  FI: "🇫🇮",
-  PT: "🇵🇹",
-  CZ: "🇨🇿",
-  RO: "🇷🇴",
-  HU: "🇭🇺",
-  AT: "🇦🇹",
-  CH: "🇨🇭",
-  BE: "🇧🇪",
-  IE: "🇮🇪",
-  SG: "🇸🇬",
-};
+// ---------------------------------------------------------------------------
+// Rate limiting — module-level, in-memory.
+// Not persistent across cold starts (serverless constraint — no Redis in this
+// stack). Provides real protection against burst submissions from a single IP
+// within a warm instance lifetime. Window: 5 submissions per 10 minutes.
+// ---------------------------------------------------------------------------
+const RATE_WINDOW_MS = 10 * 60 * 1000;
+const RATE_MAX = 5;
+const ipLog = new Map<string, number[]>();
+
+function isRateLimited(ip: string): boolean {
+  const now = Date.now();
+  const cutoff = now - RATE_WINDOW_MS;
+  const recent = (ipLog.get(ip) ?? []).filter((t) => t > cutoff);
+  if (recent.length >= RATE_MAX) return true;
+  ipLog.set(ip, [...recent, now]);
+  return false;
+}
 
 export async function POST(request: NextRequest) {
+  const ip =
+    request.headers.get("x-forwarded-for")?.split(",")[0].trim() ??
+    request.headers.get("x-real-ip") ??
+    "unknown";
+
+  if (isRateLimited(ip)) {
+    return NextResponse.json(
+      { ok: false, error: "Too many submissions. Please try again later." },
+      { status: 429 },
+    );
+  }
+
   let body: {
     company_name?: string;
     ats_type?: string;

--- a/src/app/job/[id]/page.tsx
+++ b/src/app/job/[id]/page.tsx
@@ -172,6 +172,15 @@ export default function JobDetailPage() {
             </span>
           )}
 
+          {!job.gemini_reviewed && (
+            <span
+              title="Gemini didn't return a decision for this job, so it's shown by default rather than filtered out."
+              className="rounded-full bg-amber-500/10 px-2 py-0.5 text-[11px] text-amber-500"
+            >
+              ⚠ Not AI-reviewed (showing anyway)
+            </span>
+          )}
+
           {job.matched_skills.map((s) => (
             <span
               key={s}

--- a/src/components/dashboard/JobCard.tsx
+++ b/src/components/dashboard/JobCard.tsx
@@ -92,6 +92,16 @@ export default function JobCard({ job, onTrack, onStrategy, isTracked }: Props) 
           </span>
         )}
 
+        {!job.gemini_reviewed && (
+          <span
+            title="Gemini didn't return a decision for this job, so it's shown by default rather than filtered out."
+            className="rounded-full px-2 py-0.5 text-[11px] text-[#f59e0b]"
+            style={{ background: "rgba(245,158,11,0.12)" }}
+          >
+            ⚠ Not AI-reviewed (showing anyway)
+          </span>
+        )}
+
         {job.matched_skills.slice(0, 5).map((s) => (
           <span
             key={s}

--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -1,89 +1,60 @@
 "use client";
 // src/components/onboarding/OnboardingFlow.tsx
+//
+// Feature Request 2 (gemini-filter-audit.md): the Gemini key is optional
+// now, which removes the only reason this was ever a 2-step flow (gate
+// Step 2 behind a required Step 1). Single screen: key field (skippable)
+// + the defaults-vs-customize choice, both saved in one PATCH call.
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 
-type Step = "gemini" | "customize" | "done";
-
 export default function OnboardingFlow() {
   const router = useRouter();
-  const [step, setStep] = useState<Step>("gemini");
   const [apiKey, setApiKey] = useState("");
   const [keyError, setKeyError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  async function saveKeyAndContinue() {
-    if (!apiKey.trim()) {
-      setKeyError("A Gemini API key is required to use Job Radar.");
-      return;
-    }
-    // Basic format check (Gemini keys start with "AIza")
-    if (!apiKey.trim().startsWith("AIza")) {
-      setKeyError('This doesn\'t look like a valid Gemini API key (should start with "AIza").');
+  async function complete(useDefaults: boolean) {
+    const trimmedKey = apiKey.trim();
+
+    if (trimmedKey && !trimmedKey.startsWith("AIza")) {
+      setKeyError(
+        'This doesn\'t look like a valid Gemini API key (should start with "AIza"). Leave it blank to skip for now — you can add it later in Settings.',
+      );
       return;
     }
 
-    setLoading(true);
     setKeyError(null);
+    setLoading(true);
     try {
+      const body: Record<string, unknown> = {
+        uses_defaults: useDefaults,
+        onboarding_complete: true,
+      };
+      if (trimmedKey) body.gemini_api_key = trimmedKey;
+
       const res = await fetch("/api/settings", {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ gemini_api_key: apiKey.trim() }),
+        body: JSON.stringify(body),
       });
       const data = await res.json();
-      if (data.ok) {
-        setStep("customize");
-      } else {
+      if (!data.ok) {
         setKeyError(data.error);
+        setLoading(false);
+        return;
       }
+      router.push(useDefaults ? "/dashboard" : "/settings");
     } catch {
       setKeyError("Network error. Please try again.");
-    } finally {
       setLoading(false);
     }
-  }
-
-  async function skipCustomisation() {
-    setLoading(true);
-    // uses_defaults = true (already the DB default), just mark onboarding done
-    await fetch("/api/settings", {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ uses_defaults: true, onboarding_complete: true }),
-    });
-    router.push("/dashboard");
-  }
-
-  async function goCustomise() {
-    // Mark onboarding done, send to settings page to customise
-    setLoading(true);
-    await fetch("/api/settings", {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ uses_defaults: false, onboarding_complete: true }),
-    });
-    router.push("/settings");
   }
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-[#08080f] p-4 font-sans">
       <div className="w-full max-w-[520px] rounded-2xl border border-[#1e1e30] bg-[#0d0d1a] px-9 py-10">
-        {/* Progress indicator */}
-        <div className="mb-8 flex gap-1.5">
-          {(["gemini", "customize"] as Step[]).map((s) => (
-            <div
-              key={s}
-              className="h-[3px] flex-1 rounded-sm"
-              style={{
-                background:
-                  step === s || (step === "customize" && s === "gemini") ? "#6366f1" : "#1e1e30",
-              }}
-            />
-          ))}
-        </div>
-
         {/* Logo */}
         <div className="mb-7 text-center">
           <div className="mb-2 text-4xl">🎯</div>
@@ -91,99 +62,80 @@ export default function OnboardingFlow() {
           <p className="mt-2 text-sm text-[#64748b]">Your personal AI-powered job feed</p>
         </div>
 
-        {/* Step 1: Gemini Key */}
-        {step === "gemini" && (
-          <>
-            <div className="mb-6 rounded-[10px] border border-[#1e1e30] bg-[#0a0a18] p-4">
-              <p className="text-[13px] leading-relaxed text-[#94a3b8]">
-                Job Radar uses your own <strong className="text-[#818cf8]">Gemini API key</strong>{" "}
-                to filter jobs with your custom prompt. This keeps your filtering private and
-                prevents shared rate limits.
-              </p>
+        {/* Gemini key — optional */}
+        <div className="mb-6 rounded-[10px] border border-[#1e1e30] bg-[#0a0a18] p-4">
+          <p className="text-[13px] leading-relaxed text-[#94a3b8]">
+            Add your own <strong className="text-[#818cf8]">Gemini API key</strong> to have jobs
+            filtered with your custom prompt. Optional — without one, jobs are still shown using
+            your settings filters, just clearly marked as not AI-reviewed. You can add or change
+            this anytime in Settings.
+          </p>
+        </div>
+
+        <label htmlFor="onboarding-gemini-key" className="mb-2 block text-[13px] text-[#94a3b8]">
+          Gemini API key <span className="text-[#64748b]">(optional)</span>
+        </label>
+        <input
+          id="onboarding-gemini-key"
+          type="password"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          placeholder="AIza... (leave blank to skip)"
+          className="w-full rounded-lg border bg-[#0a0a18] px-3.5 py-3 text-sm text-[#e2e8f0]"
+          style={{
+            borderColor: keyError ? "#ef4444" : "#1e1e30",
+            marginBottom: keyError ? 8 : 20,
+          }}
+        />
+        {keyError && <p className="mb-4 text-xs text-[#f87171]">{keyError}</p>}
+
+        <p className="mb-7 text-xs leading-normal text-[#475569]">
+          Get a free API key at{" "}
+          <a
+            href="https://aistudio.google.com/apikey"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[#818cf8]"
+          >
+            aistudio.google.com/apikey
+          </a>
+          . The key is stored encrypted in your profile — it never leaves our servers unencrypted,
+          and is used only for your own filter and strategy generation.
+        </p>
+
+        {/* Defaults or customise — same screen */}
+        <p className="mb-4 text-[15px] leading-relaxed text-[#94a3b8]">
+          Now choose how you want your feed configured:
+        </p>
+
+        <div className="flex flex-col gap-3.5">
+          <button
+            onClick={() => complete(true)}
+            disabled={loading}
+            className="cursor-pointer rounded-[10px] border border-[#1e1e30] bg-[#0a0a18] px-6 py-5 text-left text-[#e2e8f0] disabled:cursor-not-allowed"
+            style={{ opacity: loading ? 0.6 : 1 }}
+          >
+            <div className="mb-1 text-[15px] font-semibold">⚡ Use platform defaults</div>
+            <div className="text-[13px] text-[#64748b]">
+              Immediately see jobs matched against the default Senior React/Next.js profile. You can
+              always customise later.
             </div>
+          </button>
 
-            <label
-              htmlFor="onboarding-gemini-key"
-              className="mb-2 block text-[13px] text-[#94a3b8]"
-            >
-              Gemini API key <span className="text-[#ef4444]">*</span>
-            </label>
-            <input
-              id="onboarding-gemini-key"
-              type="password"
-              value={apiKey}
-              onChange={(e) => setApiKey(e.target.value)}
-              placeholder="AIza..."
-              className="w-full rounded-lg border bg-[#0a0a18] px-3.5 py-3 text-sm text-[#e2e8f0]"
-              style={{
-                borderColor: keyError ? "#ef4444" : "#1e1e30",
-                marginBottom: keyError ? 8 : 20,
-              }}
-            />
-            {keyError && <p className="mb-4 text-xs text-[#f87171]">{keyError}</p>}
-
-            <p className="mb-5 text-xs leading-normal text-[#475569]">
-              Get a free API key at{" "}
-              <a
-                href="https://aistudio.google.com/apikey"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-[#818cf8]"
-              >
-                aistudio.google.com/apikey
-              </a>
-              . The key is stored encrypted in your profile — it never leaves our servers
-              unencrypted, and is used only for your own filter and strategy generation.
-            </p>
-
-            <button
-              onClick={saveKeyAndContinue}
-              disabled={loading}
-              className="w-full cursor-pointer rounded-lg border-0 bg-[#6366f1] py-[13px] text-[15px] font-semibold text-white disabled:cursor-not-allowed"
-              style={{ opacity: loading ? 0.7 : 1 }}
-            >
-              {loading ? "Saving..." : "Continue →"}
-            </button>
-          </>
-        )}
-
-        {/* Step 2: Skip or Customise */}
-        {step === "customize" && (
-          <>
-            <p className="mb-7 text-[15px] leading-relaxed text-[#94a3b8]">
-              Your API key is saved. Now choose how you want your feed configured:
-            </p>
-
-            <div className="flex flex-col gap-3.5">
-              <button
-                onClick={skipCustomisation}
-                disabled={loading}
-                className="cursor-pointer rounded-[10px] border border-[#1e1e30] bg-[#0a0a18] px-6 py-5 text-left text-[#e2e8f0] disabled:cursor-not-allowed"
-                style={{ opacity: loading ? 0.6 : 1 }}
-              >
-                <div className="mb-1 text-[15px] font-semibold">⚡ Use platform defaults</div>
-                <div className="text-[13px] text-[#64748b]">
-                  Immediately see jobs matched against the default Senior React/Next.js profile. You
-                  can always customise later.
-                </div>
-              </button>
-
-              <button
-                onClick={goCustomise}
-                disabled={loading}
-                className="cursor-pointer rounded-[10px] border border-[#6366f1] bg-[#0f0f20] px-6 py-5 text-left text-[#e2e8f0] disabled:cursor-not-allowed"
-                style={{ opacity: loading ? 0.6 : 1 }}
-              >
-                <div className="mb-1 text-[15px] font-semibold text-[#818cf8]">
-                  🎛️ Customise my profile
-                </div>
-                <div className="text-[13px] text-[#64748b]">
-                  Set your own skills, pipelines, seniority preferences, and Gemini filter prompt.
-                </div>
-              </button>
+          <button
+            onClick={() => complete(false)}
+            disabled={loading}
+            className="cursor-pointer rounded-[10px] border border-[#6366f1] bg-[#0f0f20] px-6 py-5 text-left text-[#e2e8f0] disabled:cursor-not-allowed"
+            style={{ opacity: loading ? 0.6 : 1 }}
+          >
+            <div className="mb-1 text-[15px] font-semibold text-[#818cf8]">
+              🎛️ Customise my profile
             </div>
-          </>
-        )}
+            <div className="text-[13px] text-[#64748b]">
+              Set your own skills, pipelines, seniority preferences, and Gemini filter prompt.
+            </div>
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/src/lib/__tests__/gemini.test.ts
+++ b/src/lib/__tests__/gemini.test.ts
@@ -71,6 +71,7 @@ describe("filterJobsWithGemini — index-based matching", () => {
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe("visa_gh_acme_1");
     expect(result[0].gemini_reason).toBe("Strong React match");
+    expect(result[0].gemini_reviewed).toBe(true);
   });
 
   it("fails open and logs loudly when some idx are missing from the response", async () => {
@@ -86,6 +87,7 @@ describe("filterJobsWithGemini — index-based matching", () => {
     expect(result.map((j) => j.id).sort()).toEqual(["a", "b"]);
     const bResult = result.find((j) => j.id === "b");
     expect(bResult?.gemini_reason).toBeNull();
+    expect(bResult?.gemini_reviewed).toBe(false);
     expect(errorSpy).toHaveBeenCalled();
   });
 
@@ -103,6 +105,7 @@ describe("filterJobsWithGemini — index-based matching", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].gemini_reason).toBe("real decision");
+    expect(result[0].gemini_reviewed).toBe(true);
     expect(errorSpy).toHaveBeenCalled();
   });
 
@@ -114,6 +117,7 @@ describe("filterJobsWithGemini — index-based matching", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0].gemini_reason).toBe("gemini-unavailable");
+    expect(result[0].gemini_reviewed).toBe(false);
   });
 
   it("handles malformed/non-JSON responses without crashing", async () => {
@@ -126,5 +130,6 @@ describe("filterJobsWithGemini — index-based matching", () => {
     expect(result).toHaveLength(1);
     expect(result[0].gemini_pass).toBe(true);
     expect(result[0].gemini_reason).toBeNull();
+    expect(result[0].gemini_reviewed).toBe(false);
   });
 });

--- a/src/lib/__tests__/scoring.test.ts
+++ b/src/lib/__tests__/scoring.test.ts
@@ -355,9 +355,16 @@ describe("scoreJob", () => {
 
   it("passes gemini_pass and gemini_reason through", () => {
     const job = makeJob({ title: "Senior React Dev", description: "React TypeScript" });
-    const result = scoreJob(job, DEFAULT_SETTINGS, true, "Matches senior React profile");
+    const result = scoreJob(job, DEFAULT_SETTINGS, true, "Matches senior React profile", true);
     expect(result!.gemini_pass).toBe(true);
     expect(result!.gemini_reason).toBe("Matches senior React profile");
+    expect(result!.gemini_reviewed).toBe(true);
+  });
+
+  it("defaults gemini_reviewed to false when not passed", () => {
+    const job = makeJob({ title: "Senior React Dev", description: "React TypeScript" });
+    const result = scoreJob(job, DEFAULT_SETTINGS);
+    expect(result!.gemini_reviewed).toBe(false);
   });
 });
 
@@ -375,6 +382,7 @@ describe("mergeJobs", () => {
       bonus_skills: [],
       gemini_pass: true,
       gemini_reason: null,
+      gemini_reviewed: true,
     };
   }
 
@@ -475,5 +483,58 @@ describe("passesSettingsGate", () => {
       secondary_skills: ["Vue"],
     };
     expect(passesSettingsGate(job, settings)).toBe(false);
+  });
+
+  // ── Bug 2: boilerplate-aware matching ──────────────────────
+  // Confirmed against live raw_jobs: every Vercel posting (engineering or
+  // not) opens with an identical ~788-char "About Vercel: ... the team
+  // behind Next.js" intro. Non-engineering roles never mention React/
+  // Next.js again anywhere else in the posting.
+
+  function makeBoilerplateDescription(roleSection: string): string {
+    const intro =
+      "About Vercel: Vercel is the agentic infrastructure company. We free people and agents " +
+      "to ship what's next. For more than a decade, Vercel has shaped how the web is built. As " +
+      "the team behind Next.js, v0, and AI SDK, we create products that help builders move from " +
+      "idea to production with speed, security, and exceptional developer experience. Now, " +
+      "software is entering a new era, and the next generation of products will not just be " +
+      "used by people."; // ~430 chars on its own; padded below to clear the 600-char window
+    const padding = "Filler company-mission copy padding this intro out further. ".repeat(4); // ~250 chars
+    return `${intro} ${padding}${roleSection}`;
+  }
+
+  it("rejects a non-engineering role whose only keyword match is the company-intro boilerplate", () => {
+    const job = makeJob({
+      title: "Account Executive- Startups, Greenfield",
+      description: makeBoilerplateDescription(
+        "About the Role: You'll build relationships with founders and close new business. " +
+          "5+ years of SaaS sales experience required. No frontend or engineering skills needed.",
+      ),
+    });
+    expect(passesSettingsGate(job, DEFAULT_SETTINGS)).toBe(false);
+  });
+
+  it("accepts an engineering role that mentions the keyword again past the intro", () => {
+    const job = makeJob({
+      title: "Software Engineer, eve",
+      description: makeBoilerplateDescription(
+        "About the role: We are looking for a Software Engineer to help build eve, Vercel's " +
+          "framework for production-ready AI agents. Eve is to agents what Next.js is to web apps. " +
+          "Drive DX quality so TypeScript/Next.js developers can ship their first agent in minutes.",
+      ),
+    });
+    expect(passesSettingsGate(job, DEFAULT_SETTINGS)).toBe(true);
+  });
+
+  it("accepts a long posting with two distinct keyword matches even when both sit inside the window", () => {
+    const job = makeJob({
+      title: "Frontend Engineer",
+      description:
+        "React and TypeScript experience required. React Native is a plus. " +
+        "Padding text with no relevant keywords to push total length well past six hundred characters total. ".repeat(
+          8,
+        ),
+    });
+    expect(passesSettingsGate(job, DEFAULT_SETTINGS)).toBe(true);
   });
 });

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -1,19 +1,38 @@
 // src/lib/api-errors.ts
-// Shared error-response helper for API route handlers.
+// Shared error-response helpers for API route handlers.
 
 import { NextResponse } from "next/server";
 
 /**
- * Logs the real database/error detail server-side and returns a generic
- * message to the client. Use this instead of putting `error.message`
- * straight into the JSON response — raw Supabase errors can leak schema,
- * query, or RLS policy details to callers.
+ * For Supabase query errors: logs the real error server-side and returns a
+ * generic message to the client. Prevents raw Supabase messages (which can
+ * leak schema, query, or RLS policy details) from reaching callers.
  *
  *   const { data, error } = await db.from("tracker_entries").select("*");
  *   if (error) return dbErrorResponse("tracker:GET", error);
  */
 export function dbErrorResponse(context: string, error: { message: string }) {
   console.error(`[${context}]`, error.message);
+  return NextResponse.json(
+    { ok: false, error: "Something went wrong. Please try again." },
+    { status: 500 },
+  );
+}
+
+/**
+ * For caught thrown errors (internal function calls, third-party SDKs, etc.):
+ * logs the real message server-side and returns a generic message to the
+ * client. Use in catch blocks where the thrown value is `unknown`.
+ *
+ *   try {
+ *     await someInternalCall();
+ *   } catch (err) {
+ *     return catchErrorResponse("strategy:POST", err);
+ *   }
+ */
+export function catchErrorResponse(context: string, err: unknown) {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(`[${context}]`, message);
   return NextResponse.json(
     { ok: false, error: "Something went wrong. Please try again." },
     { status: 500 },

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -58,7 +58,65 @@ export const COUNTRY_MAP: Record<string, { name: string; flag: string }> = {
   uae: { name: "UAE", flag: "🇦🇪" },
   dubai: { name: "UAE", flag: "🇦🇪" },
   riyadh: { name: "Saudi Arabia", flag: "🇸🇦" },
+  // Added: countries present in COUNTRY_FLAGS but previously missing here
+  "czech republic": { name: "Czech Republic", flag: "🇨🇿" },
+  czechia: { name: "Czech Republic", flag: "🇨🇿" },
+  prague: { name: "Czech Republic", flag: "🇨🇿" },
+  romania: { name: "Romania", flag: "🇷🇴" },
+  bucharest: { name: "Romania", flag: "🇷🇴" },
+  hungary: { name: "Hungary", flag: "🇭🇺" },
+  budapest: { name: "Hungary", flag: "🇭🇺" },
+  austria: { name: "Austria", flag: "🇦🇹" },
+  vienna: { name: "Austria", flag: "🇦🇹" },
+  switzerland: { name: "Switzerland", flag: "🇨🇭" },
+  zurich: { name: "Switzerland", flag: "🇨🇭" },
+  geneva: { name: "Switzerland", flag: "🇨🇭" },
+  belgium: { name: "Belgium", flag: "🇧🇪" },
+  brussels: { name: "Belgium", flag: "🇧🇪" },
+  singapore: { name: "Singapore", flag: "🇸🇬" },
+  norway: { name: "Norway", flag: "🇳🇴" },
+  oslo: { name: "Norway", flag: "🇳🇴" },
+  canada: { name: "Canada", flag: "🇨🇦" },
+  toronto: { name: "Canada", flag: "🇨🇦" },
+  australia: { name: "Australia", flag: "🇦🇺" },
+  sydney: { name: "Australia", flag: "🇦🇺" },
   remote: { name: "Remote", flag: "🌍" },
+};
+
+/**
+ * ISO 3166-1 alpha-2 code → flag emoji.
+ * Used by submit/route.ts to stamp a flag on incoming company submissions.
+ * Keep in sync with COUNTRY_MAP — every flag here should have a corresponding
+ * name/city entry there so scraped jobs and submissions resolve consistently.
+ */
+export const COUNTRY_FLAGS: Record<string, string> = {
+  US: "🇺🇸",
+  UK: "🇬🇧",
+  GB: "🇬🇧",
+  DE: "🇩🇪",
+  FR: "🇫🇷",
+  EG: "🇪🇬",
+  NL: "🇳🇱",
+  ES: "🇪🇸",
+  IT: "🇮🇹",
+  PL: "🇵🇱",
+  CA: "🇨🇦",
+  AU: "🇦🇺",
+  SE: "🇸🇪",
+  NO: "🇳🇴",
+  DK: "🇩🇰",
+  FI: "🇫🇮",
+  PT: "🇵🇹",
+  CZ: "🇨🇿",
+  RO: "🇷🇴",
+  HU: "🇭🇺",
+  AT: "🇦🇹",
+  CH: "🇨🇭",
+  BE: "🇧🇪",
+  IE: "🇮🇪",
+  SG: "🇸🇬",
+  SA: "🇸🇦", // previously missing — Saudi Arabia
+  AE: "🇦🇪", // previously missing — UAE
 };
 
 export const MODE_COLORS: Record<string, string> = {

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -38,6 +38,11 @@ interface FilterResult {
   id: string;
   pass: boolean;
   reason: string | null;
+  // true only when Gemini returned a real, matched decision for this job's
+  // idx. false for both fail-open paths (missing idx in an otherwise-valid
+  // response, or total batch failure). See Feature Request 1 in
+  // docs/plans/2026-06-24-gemini-reviewed-indicator.md.
+  reviewed: boolean;
 }
 
 // ── Core call with model fallback ────────────────────────────
@@ -111,7 +116,13 @@ async function filterBatch(
     title: j.title,
     company: j.company,
     location: j.location,
-    description: j.description.slice(0, 1200), // truncate for token limit
+    // 3000 chars (Bug 3, gemini-filter-audit.md — raised from 1200, to
+    // match the old ingestion ceiling). Deliberately less than the new
+    // 6000-char ingestion ceiling in ats-utils.ts's processJobs — Gemini's
+    // cost scales with tokens sent (BATCH_SIZE=30 jobs/call), while the
+    // free settings-gate pre-filter gets the full benefit of the larger
+    // window. See processJobs's comment for the full tradeoff.
+    description: j.description.slice(0, 3000),
   }));
 
   const prompt = `${promptTemplate}
@@ -154,6 +165,7 @@ ${JSON.stringify(jobSummaries, null, 2)}`;
         id: job.id,
         pass: Boolean(d.pass),
         reason: d.reason ?? null,
+        reviewed: true,
       });
     }
 
@@ -170,14 +182,14 @@ ${JSON.stringify(jobSummaries, null, 2)}`;
     // If Gemini fails for this batch, pass all jobs through (fail-open)
     console.error("[gemini] Batch filter failed:", err);
     for (const j of jobs) {
-      resultMap.set(j.id, { id: j.id, pass: true, reason: "gemini-unavailable" });
+      resultMap.set(j.id, { id: j.id, pass: true, reason: "gemini-unavailable", reviewed: false });
     }
   }
 
   // Any job not in Gemini's response → default to pass (fail-open)
   for (const j of jobs) {
     if (!resultMap.has(j.id)) {
-      resultMap.set(j.id, { id: j.id, pass: true, reason: null });
+      resultMap.set(j.id, { id: j.id, pass: true, reason: null, reviewed: false });
     }
   }
 
@@ -196,10 +208,14 @@ export async function filterJobsWithGemini(
   apiKey: string,
   jobs: RawJob[],
   settings: Pick<ResolvedSettings, "gemini_filter_prompt">,
-): Promise<Array<RawJob & { gemini_pass: boolean; gemini_reason: string | null }>> {
+): Promise<
+  Array<RawJob & { gemini_pass: boolean; gemini_reason: string | null; gemini_reviewed: boolean }>
+> {
   if (!apiKey || !jobs.length) return [];
 
-  const results: Array<RawJob & { gemini_pass: boolean; gemini_reason: string | null }> = [];
+  const results: Array<
+    RawJob & { gemini_pass: boolean; gemini_reason: string | null; gemini_reviewed: boolean }
+  > = [];
   const prompt = settings.gemini_filter_prompt;
 
   // Process in batches
@@ -210,7 +226,12 @@ export async function filterJobsWithGemini(
     for (const job of batch) {
       const d = decisions.get(job.id);
       if (d?.pass) {
-        results.push({ ...job, gemini_pass: true, gemini_reason: d.reason });
+        results.push({
+          ...job,
+          gemini_pass: true,
+          gemini_reason: d.reason,
+          gemini_reviewed: d.reviewed,
+        });
       }
     }
   }

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -25,6 +25,61 @@ const SENIOR_KEYWORDS = /\b(senior|sr\.?|principal|staff|lead)\b/i;
 const MID_KEYWORDS = /\b(mid[-\s]?level|mid[-\s]?senior|intermediate)\b/i;
 const JUNIOR_KEYWORDS = /\b(junior|jr\.?|entry[\s-]?level|intern|graduate)\b/i;
 
+// ── Boilerplate-aware keyword matching (Bug 2, gemini-filter-audit.md) ──
+
+/**
+ * Many ATS postings open with a long "About [Company]" boilerplate
+ * paragraph that mentions the company's own product/stack regardless of
+ * the specific role — e.g. every Vercel posting (Account Executive,
+ * Senior HRBP, Partner Operations Lead, ...) opens with "the team behind
+ * Next.js". A naive "does this keyword appear anywhere" check treats that
+ * boilerplate identically to a real requirements section, which produced
+ * a 100% false-positive rate for non-engineering Vercel roles — confirmed
+ * against live raw_jobs data. See
+ * docs/plans/2026-06-24-bug2-boilerplate-keyword-gate.md.
+ *
+ * 600 chars comfortably covers the confirmed Vercel intro (~788 chars,
+ * only match at ~190).
+ */
+const BOILERPLATE_WINDOW_CHARS = 600;
+
+function wordBoundaryPattern(word: string): string {
+  const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/\s+/g, "\\s+");
+  return `\\b${escaped}\\b`;
+}
+
+/**
+ * Returns true if `keywords` has a "meaningful" match in `text`: either a
+ * match past the boilerplate-prone opening window, or two or more distinct
+ * keywords matched anywhere (breadth). Texts at or under the window size
+ * are exempt from the position check — too short for a real "intro vs.
+ * body" split, so a single early match is trusted as before.
+ */
+export function hasMeaningfulKeywordMatch(text: string, keywords: string[]): boolean {
+  if (text.length <= BOILERPLATE_WINDOW_CHARS) {
+    return keywords.some((word) => new RegExp(wordBoundaryPattern(word), "i").test(text));
+  }
+
+  let distinctMatchCount = 0;
+  let matchOutsideWindow = false;
+
+  for (const word of keywords) {
+    const regex = new RegExp(wordBoundaryPattern(word), "gi");
+    let matchedThisWord = false;
+    let m: RegExpExecArray | null;
+    while ((m = regex.exec(text)) !== null) {
+      matchedThisWord = true;
+      if (m.index >= BOILERPLATE_WINDOW_CHARS) {
+        matchOutsideWindow = true;
+      }
+      if (m.index === regex.lastIndex) regex.lastIndex++; // guard against zero-length matches
+    }
+    if (matchedThisWord) distinctMatchCount++;
+  }
+
+  return matchOutsideWindow || distinctMatchCount >= 2;
+}
+
 // ── Recency ──────────────────────────────────────────────────
 
 /**
@@ -149,12 +204,7 @@ export function passesSettingsGate(job: RawJob, settings: ResolvedSettings): boo
       : settings.expert_skills;
 
   if (techKeywords && techKeywords.length > 0) {
-    const hasRequired = techKeywords.some((word) => {
-      const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/\s+/g, "\\s+");
-      const regex = new RegExp(`\\b${escaped}\\b`, "i");
-      return regex.test(textCombined);
-    });
-    if (!hasRequired) {
+    if (!hasMeaningfulKeywordMatch(textCombined, techKeywords)) {
       return false;
     }
   }
@@ -171,10 +221,15 @@ export function passesSettingsGate(job: RawJob, settings: ResolvedSettings): boo
     }
   }
 
-  // 5. Skill Match Check: Ensure there is at least one skill match from the user's stack to keep relevancy high
-  const expertMatched = matchSkills(job.description, settings.expert_skills);
-  const secondaryMatched = matchSkills(job.description, settings.secondary_skills);
-  if (expertMatched.length === 0 && secondaryMatched.length === 0) {
+  // 5. Skill Match Check: Ensure there is at least one *meaningful* skill
+  // match from the user's stack to keep relevancy high (Bug 2: boilerplate-
+  // aware — see hasMeaningfulKeywordMatch above).
+  if (
+    !hasMeaningfulKeywordMatch(job.description, [
+      ...settings.expert_skills,
+      ...settings.secondary_skills,
+    ])
+  ) {
     return false;
   }
 
@@ -211,6 +266,7 @@ export function scoreJob(
   settings: ResolvedSettings,
   geminiPass = false,
   geminiReason: string | null = null,
+  geminiReviewed = false,
 ): ScoredJob | null {
   // Seniority hard gate – null means "do not store at all"
   if (!passesSeniorityGate(job, settings.seniority_allow_mid)) {
@@ -249,6 +305,7 @@ export function scoreJob(
     bonus_skills,
     gemini_pass: geminiPass,
     gemini_reason: geminiReason,
+    gemini_reviewed: geminiReviewed,
   };
 }
 

--- a/src/lib/sources/ats-utils.ts
+++ b/src/lib/sources/ats-utils.ts
@@ -16,6 +16,7 @@ import type {
   SRJob,
   SRDetail,
   BambooJob,
+  BambooDetail,
   JazzJob,
   DomainCounts,
   WorkableCooldownEntry,
@@ -324,7 +325,13 @@ export function processJobs(
       // Flat truncation for all jobs now — the old "shrink non-matches" policy
       // existed because everything was pre-filtered by skill match at ingestion.
       // That gate is gone; storage policy shouldn't reintroduce the same bias.
-      description: r.description.slice(0, 3000),
+      // 6000 chars (Bug 3, gemini-filter-audit.md — raised from 3000 after
+      // confirming live raw_jobs data was hitting the old ceiling on every
+      // one of its 20 longest descriptions). This is the absolute ceiling
+      // on what's ever stored, and what passesSettingsGate searches against;
+      // see gemini.ts's filterBatch for the separate, smaller Gemini-call
+      // truncation and why the two are deliberately not equal.
+      description: r.description.slice(0, 6000),
       isRemote,
       postedAt: r.postedAt || now,
       dateUnknown: !r.postedAt,
@@ -873,19 +880,32 @@ export async function fetchBambooHR(
     const data = (await res.json()) as { result?: BambooJob[] };
     const jobs = data.result ?? [];
     const rawCount = jobs.length;
-    const processed = processJobs(
-      jobs.map((r) => ({
-        id: `${mode}_bamboohr_${c.slug}_${r.id}`,
-        title: r.jobOpeningName,
-        location: r.city ? `${r.city}, ${r.country}` : (c.city ?? c.country),
-        url: `https://${c.slug}.bamboohr.com/careers/${r.id}`,
-        postedAt: r.datePosted,
-        description: "",
-      })),
-      c,
-      mode,
-      visaSponsorship,
+    // BambooHR's list endpoint never includes a description (Bug 4,
+    // gemini-filter-audit.md) — fetch each job's detail page for the real
+    // description, mirroring fetchWorkable's detail-fetch pattern.
+    const withDesc = await pLimit(
+      jobs.map((r) => async () => {
+        let description = "";
+        const detailUrl = `https://${c.slug}.bamboohr.com/careers/${r.id}/detail`;
+        const dr = await safeFetch(detailUrl);
+        if (dr && dr.ok) {
+          try {
+            const detail = (await dr.json()) as BambooDetail;
+            description = stripHtml(detail.result?.jobOpening?.description ?? "");
+          } catch {}
+        }
+        return {
+          id: `${mode}_bamboohr_${c.slug}_${r.id}`,
+          title: r.jobOpeningName,
+          location: r.city ? `${r.city}, ${r.country}` : (c.city ?? c.country),
+          url: `https://${c.slug}.bamboohr.com/careers/${r.id}`,
+          postedAt: r.datePosted,
+          description,
+        };
+      }),
+      5,
     );
+    const processed = processJobs(withDesc.filter(Boolean) as RawJob[], c, mode, visaSponsorship);
     return { jobs: processed, rawCount, durationMs: Date.now() - t0, ok: true };
   } catch (e) {
     return {

--- a/src/lib/sources/ats-utils.ts
+++ b/src/lib/sources/ats-utils.ts
@@ -647,10 +647,6 @@ export async function fetchWorkable(
     );
     const processed = processJobs(withDesc.filter(Boolean) as RawJob[], c, mode, visaSponsorship);
 
-    console.log(
-      `[workable] ${c.name.padEnd(20)} | Raw: ${String(rawCount).padStart(3)} | Matched: ${String(processed.length).padStart(2)}`,
-    );
-
     return { jobs: processed, rawCount, durationMs: Date.now() - t0, ok: true };
   } catch (e) {
     return {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -73,6 +73,11 @@ export interface ScoredJob extends RawJob {
   bonus_skills: string[]; // nice-to-have skills found, informational only — never scored
   gemini_pass: boolean;
   gemini_reason: string | null;
+  /** true only when Gemini returned a real, matched decision for this job;
+   *  false when it fell through a fail-open path (missing idx or batch
+   *  failure) — see Feature Request 1 in
+   *  docs/plans/2026-06-24-gemini-reviewed-indicator.md. */
+  gemini_reviewed: boolean;
   scoring_weights?: ScoringWeights;
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -132,6 +132,16 @@ export interface BambooJob {
   datePosted: string;
 }
 
+/** Shape of GET https://{slug}.bamboohr.com/careers/{id}/detail (Bug 4,
+ * gemini-filter-audit.md). Only the field this codebase actually reads. */
+export interface BambooDetail {
+  result?: {
+    jobOpening?: {
+      description?: string;
+    };
+  };
+}
+
 export interface JazzJob {
   id: string;
   title: string;


### PR DESCRIPTION
[fix(cleanup): phase5 error-handling leftovers + non-blocking items](https://github.com/mazenemam19/job-radar/commit/d67ea98d34d365fc52e98ff29779e4c01c55cdec) 

Phase 5 leftovers — 3 catch blocks still leaking internal error messages:

- src/lib/api-errors.ts: add catchErrorResponse(context, err: unknown).
  Companion to dbErrorResponse() for caught thrown errors rather than Supabase
  query errors. Handles the instanceof Error check once; callers pass context
  tag and the unknown.

- api/cron/route.ts: replace inline console.error + raw message response with
  catchErrorResponse("cron", err). Log moves into the helper; raw message no
  longer reaches the caller.

- api/settings/route.ts: replace raw message response in the saveUserSettings
  catch block with catchErrorResponse("settings:PATCH", err). Previously had
  no server-side logging at all.

- api/strategy/route.ts: replace raw message response in the
  generateApplicationStrategy catch block with catchErrorResponse(
  "strategy:POST", err). Gemini errors can include prompt fragments and quota
  details — none of that should reach the client.

Non-blocking cleanup:

- src/lib/sources/ats-utils.ts: remove fetchWorkable's per-company console.log.
  Only one of 9 fetchers emitted it, making cron logs look like only Workable
  was running. Redundant with cron_logs_v2.

- src/lib/constants.ts: move COUNTRY_FLAGS here from submit/route.ts. Add SA
  and AE (were in COUNTRY_MAP but missing from COUNTRY_FLAGS — Riyadh/Dubai
  submissions got 🌍 while scraped jobs got the real flag). Add 7 countries to
  COUNTRY_MAP that existed in COUNTRY_FLAGS but had no name/city entries:
  CZ/RO/HU/AT/CH/BE/SG + capitals. Also NO/CA/AU for completeness.

- api/submit/route.ts: import COUNTRY_FLAGS from constants. Add module-level
  in-memory rate limiter: 5 submissions per IP per 10-minute window. Reads
  x-forwarded-for then x-real-ip; falls back to "unknown" bucket. Returns 429
  on breach. Not persistent across cold starts — documented in a comment.

Validation: tsc --noEmit clean, 65/65 vitest tests passing, next build
successful (30 routes compiled).

_____

[Fix: gemini filteration and optional gemini key in onboardinng](https://github.com/mazenemam19/job-radar/commit/eb1d436ac65ff01acfdcc7b0181370d884458e07) 

- gemini: add gemini_reviewed flag to FilterResult/ScoredJob; true only
  for a real matched idx decision, false for both fail-open paths
  (missing idx and total batch failure). Surfaces as a "⚠ Not AI-reviewed
  (showing anyway)" badge on JobCard and job detail page.

- scoring: boilerplate-aware required-keyword gate — stops required
  keywords from matching generic filler text in descriptions, reducing
  false positives on jobs that mention React only in passing.

- sources: BambooHR detail fetch now retrieves the real job description
  instead of falling back to the listing snippet.

- scoring: raise description truncation limits so longer postings are not
  penalised on skill matching.

- onboarding: Gemini key is now optional; key + defaults/customise choice
  collapsed into one screen instead of two sequential steps.
