### PR TITLE
fix: split email-alerts toggle, gate salary cron on it, add review badge to alert email

### DIFF
--- a/docs/plans/2026-06-25-email-toggle-split-and-review-badge.md
+++ b/docs/plans/2026-06-25-email-toggle-split-and-review-badge.md
@@ -1,0 +1,139 @@
+# Resolution: Split email-alerts toggle into two; add review badge to alert email
+
+**Status: implemented.** Found during the JD-truncation fix review when the
+salary-reminder cron toggle was checked. Two related fixes, bundled here
+because both touch the same toggle/email surface.
+
+## Bug found
+
+`SettingsForm.tsx`'s single "Email Alerts" toggle (`email_alerts_enabled`)
+is correctly gated for job-match alerts —
+`dashboard/route.ts`: `if (hadPreviousCache && settings.email_alerts_enabled && user.email)`
+before calling `sendJobAlertEmail`.
+
+It is **not** gated for the monthly salary-reminder cron at all.
+`scripts/send-salary-reminders.ts` queried `salary_reports` joined only to
+`user_profiles(email, is_active)` — it never read `user_settings` or
+`email_alerts_enabled`. Anyone whose report was stale and whose account was
+active got the reminder, full stop.
+
+The toggle's own UI copy claimed otherwise:
+_"Also includes a monthly reminder to update your salary report."_
+A user who disabled the toggle to stop job alerts was still getting the
+monthly salary nag every 1st of the month — the UI promised behavior the
+backend never implemented.
+
+## Decision: two independent toggles, not one
+
+Job alerts and salary reminders are different products: frequent/personalized
+vs. monthly/community-contribution-nudge. Coupling them under one switch
+means a user who wants one but not the other has no way to express that —
+the realistic failure mode is someone gets annoyed by one and kills both,
+including the one they'd have kept. The fix to wire _something_ into the
+salary script was required regardless of which design was chosen; splitting
+costs one extra boolean column and one extra UI toggle on top of that
+baseline.
+
+## Implementation
+
+### Schema (manual migration — this repo doesn't track migrations in
+
+`supabase/`; run directly against the project)
+
+```sql
+alter table public.user_settings
+  add column if not exists salary_reminder_enabled boolean;
+
+alter table public.default_settings
+  add column if not exists salary_reminder_enabled boolean not null default true;
+
+update public.default_settings set salary_reminder_enabled = true where id = 1;
+```
+
+`user_settings.salary_reminder_enabled` is nullable, matching every other
+per-user override field's convention (null = inherit default).
+`default_settings.salary_reminder_enabled` is `NOT NULL DEFAULT true` —
+existing users keep getting reminders unless they explicitly opt out, same
+as `email_alerts_enabled`'s rollout.
+
+### `src/lib/types.ts`
+
+Added `salary_reminder_enabled` to `DefaultSettings`, `UserSettingsRow`
+(nullable), `ResolvedSettings`.
+
+### `src/lib/settings.ts`
+
+- `FALLBACK_DEFAULTS.salary_reminder_enabled = true`.
+- Both the `uses_defaults` branch and `mergeWithDefaults` resolve it as
+  `userRow.salary_reminder_enabled ?? defaults.salary_reminder_enabled` —
+  same merge rule as `email_alerts_enabled`: respected even when the user
+  is otherwise on platform defaults for skills/prompt/etc.
+- Added to `saveUserSettings`'s `allowed` whitelist.
+
+### `src/components/settings/SettingsForm.tsx`
+
+Split the single Toggle into two, both still under the "Email Alerts"
+section heading:
+
+- "Email me when new matches are found" — copy trimmed to drop the
+  salary-reminder claim.
+- "Monthly salary update reminder" — new toggle, new state, included in the
+  PATCH body.
+
+### `scripts/send-salary-reminders.ts`
+
+- Query now embeds `user_settings(salary_reminder_enabled)` alongside the
+  existing `user_profiles!inner(email, is_active)` embed.
+- Fetches `default_settings.salary_reminder_enabled` once up front as the
+  fallback for users with no `user_settings` row (just signed up, never
+  opened `/settings`) or a null value in it.
+- Filter step resolves per-row: `settingsRow?.[0]?.salary_reminder_enabled ?? defaultSalaryReminderEnabled`.
+  The `?.[0]` handles Supabase embedding a to-one relation as a one-element
+  array — same shape correction already applied to
+  `AdminUserListItem.user_settings` in Phase 2 of the original audit.
+- Could not reuse `resolveUserSettings()` directly: it calls
+  `createServerClient()`, which reads `next/headers`' `cookies()` and throws
+  outside a request context. This script runs standalone via `tsx`, not as
+  a route handler — same constraint `settings.test.ts` already works around
+  by stubbing `next/headers` for _tests_, which isn't an option for a
+  script that has to run for real in CI.
+
+### `src/lib/email.ts` (separate but related finding)
+
+The alert email shows `total_score` and calls jobs "matches" with no
+indication of whether Gemini ever evaluated them. `gemini_reviewed` /
+`gemini_quota_exhausted` already exist and already drive a badge on the
+dashboard and detail page (see `2026-06-25-jd-truncation-resolution.md`) —
+the email was the one surface that didn't get it. Added a `reviewBadge(job)`
+helper mirroring the same two cases and copy, inline-styled for email-client
+compatibility, rendered after the score bar and before matched skills on
+each job card — same position as `JobCard.tsx`.
+
+Score itself isn't "wrong" in these cases — `total_score` is a pure
+skill/recency/relocation calculation, independent of Gemini review status —
+but presenting it without the caveat overstates how vetted the match is.
+
+## Validation
+
+- `tsc --noEmit` clean
+- `eslint` + `prettier` clean
+- vitest: 77/77 (extended `settings.test.ts`'s existing cases rather than
+  adding new ones — asserts the new field defaults correctly, resolves
+  independently of `email_alerts_enabled` when overridden, and falls back
+  to the hardcoded default when the DB is unreachable)
+- `next build` successful, all 30 routes
+- No test added for `send-salary-reminders.ts` or `email.ts` — neither had
+  any prior coverage (consistent with how Bug 4 and Feature Request 2 in
+  the original audit left equivalent pre-existing gaps untouched). Still
+  tracked as the "Email path" test in the Roadmap's Tier 1 Playwright suite.
+
+## Not done here
+
+- The Tier 1 Playwright "Email path" smoke test (mock
+  `nodemailer.createTransport`, assert `sendMail` shape) — this would have
+  caught the original gating bug mechanically. Still pending, still
+  sequenced where the Roadmap already put it.
+- No backfill/notification to existing users that this toggle now actually
+  works as described — anyone who already turned off "Email Alerts"
+  expecting it to cover both will keep getting salary reminders until they
+  visit `/settings` again and see the new second toggle (default `true`).

--- a/docs/plans/2026-06-25-jd-truncation-resolution.md
+++ b/docs/plans/2026-06-25-jd-truncation-resolution.md
@@ -1,0 +1,163 @@
+# Resolution: Job description truncation (Bug Fix Handoff — Job Description Truncation)
+
+**Status: shipped in commit `6d2d68c` on `refactor/code-audit-and-enhancement`.**
+This doc is the completion record for that commit — written after the fact
+because `gemini.ts`'s updated comment referenced this file before it existed.
+Original handoff brief is not committed to the repo (kept alongside `audit.md`
+as planning input, same convention as `gemini-filter-audit.md`).
+
+## The problem
+
+Job descriptions were truncated at two points, and both ceilings were set
+without looking at real data:
+
+```
+Real JD (could be 27,000+ chars)
+    ↓ [1] Ingestion ceiling — ats-utils.ts processJobs()
+Stored in raw_jobs (TEXT column)
+    ↓ [2] Gemini window — gemini.ts filterBatch()
+What Gemini actually sees
+```
+
+Bug 3 (`gemini-filter-audit.md`) had already raised these once — 3000 → 6000
+(ingestion) and 1200 → 3000 (Gemini) — but that pass didn't check live data
+either. Both numbers were still wrong.
+
+## Architecture note (for context, not changed by this fix)
+
+- Cron scrapes → `raw_jobs` (global table). No Gemini call here.
+- Dashboard route (`GET /api/dashboard`) runs `passesSettingsGate` (free,
+  regex, full stored description) → `filterBatch`/Gemini (user's own API
+  key) → scores → caches → fires the new-job email.
+- Gemini fails open. A quota/error doesn't drop jobs — they show with
+  `gemini_reviewed: false`. Intentional, unchanged by this fix.
+- Email fires from the dashboard route, already post-Gemini. Users who never
+  open the dashboard never get emailed — a separate, out-of-scope product
+  issue, not touched here.
+
+## Step 1 — Remove the ingestion ceiling
+
+`ats-utils.ts`'s `processJobs` stored `r.description.slice(0, 6000)`. Changed
+to store the full description, uncapped — it's a `TEXT` column; there's no
+storage-cost reason to cap it, and the old "shrink everything" policy was a
+holdover from when ingestion also pre-filtered by skill match (it doesn't
+anymore).
+
+## What the real data showed
+
+After removing the ceiling and letting one cron cycle run, the actual
+`raw_jobs.description` length distribution:
+
+| bucket    | jobs      | avg_chars | max_chars  |
+| --------- | --------- | --------- | ---------- |
+| < 1k      | 40        | 506       | 698        |
+| 1k–2k     | 4         | 1,538     | 1,807      |
+| 2k–3k     | 62        | 2,795     | 2,999      |
+| 3k–4k     | 728       | 3,358     | 3,996      |
+| 4k–5k     | 545       | 4,479     | 4,999      |
+| 5k–6k     | 596       | 5,516     | 5,999      |
+| 6k–8k     | 1120      | 6,925     | 7,994      |
+| 8k–10k    | 588       | 8,858     | 9,998      |
+| 10k–15k   | 332       | 11,384    | 14,952     |
+| 15k–20k   | 29        | 16,430    | 19,825     |
+| 20k+      | 2         | 24,261    | 27,707     |
+| **Total** | **4,046** |           | **27,707** |
+
+Coverage at different Gemini windows:
+
+- 6,000 chars → 48.8% of jobs fully covered (the old ceiling was cutting the
+  majority)
+- 8,000 chars → 76.5%
+- 10,000 chars → **91%** ← chosen
+- 15,000 chars → 99.2%
+
+## Decisions (locked)
+
+| Decision                                   | Chosen            | Rationale                                                                                                                                                  |
+| ------------------------------------------ | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Storage ceiling                            | Remove entirely   | `TEXT` column, no upside to any ceiling                                                                                                                    |
+| Gemini chars/job                           | 10,000            | Covers 91%, data-driven; going to 15k buys only 8.2% more for a disproportionate token-cost increase                                                       |
+| Batch size                                 | 15 (down from 30) | Proportional to the larger per-job window — keeps prompt size from scaling unchecked                                                                       |
+| Disqualifier regex in `passesSettingsGate` | Rejected          | "No visa sponsorship / US only" are not universal disqualifiers — a US citizen wants those jobs. Belongs in per-user excluded keywords, not a shared gate. |
+| Gemini 429 indicator                       | Yes               | Distinguish quota exhaustion from other fail-open cases with a specific badge, not the generic "not AI-reviewed" one                                       |
+
+## Steps 2 & 3 — what was implemented
+
+Both landed together in `6d2d68c` (the handoff brief had asked for them as
+separate steps with their own validation passes; in practice they were
+implemented and validated as one commit — logged as a process finding in
+`audit.md`, not re-litigated here).
+
+**`gemini.ts`:**
+
+- `BATCH_SIZE`: 30 → 15.
+- Gemini-call description window: 3000 → 10,000 chars.
+- New `isQuotaError(msg)` helper (shared between `filterBatch`'s tracking and
+  `generateApplicationStrategy`'s existing retry logic, which had its own
+  inline copy of the same check).
+- New `GeminiQuotaExhaustedError`, thrown by `callGemini` only when every
+  model in `MODEL_QUEUE` failed and every one of those failures was
+  specifically a quota/rate-limit error (not a network error, bad response,
+  or other transient failure).
+- `FilterResult` and `filterJobsWithGemini`'s return type both gained
+  `quotaExhausted?: boolean` / `gemini_quota_exhausted: boolean`, set `true`
+  only on that specific fail-open path.
+
+**`types.ts` / `scoring.ts`:**
+
+- `ScoredJob.gemini_quota_exhausted?: boolean` (optional — most call sites
+  never hit this path).
+- `scoreJob` gained a 6th param, `geminiQuotaExhausted = false`, threaded
+  straight onto the returned job. Does not affect `total_score` — Gemini
+  review status was never part of the score calculation (it's a pure
+  skill/recency/relocation formula); this is purely a display signal.
+
+**`JobCard.tsx` / `job/[id]/page.tsx`:**
+
+- Badge logic now branches: quota-exhausted gets its own
+  "⚠ Gemini quota exhausted" badge; any other not-reviewed case keeps the
+  existing "⚠ Not AI-reviewed" badge (dropped the "(showing anyway)" suffix
+  for brevity, behavior unchanged).
+
+**`dashboard/route.ts`:**
+
+- Threads `gemini_quota_exhausted` through the no-key fallback shape and the
+  `scoreJob` call.
+
+## Validation
+
+- `tsc --noEmit` clean
+- `eslint` clean
+- vitest: 77/77 (added coverage in `gemini.test.ts` for the quota-exhausted
+  detection — full quota failure vs. mixed quota/non-quota failure — and in
+  `scoring.test.ts` for the new param threading)
+- `next build` successful, all 30 routes
+
+## Things ruled out (don't re-debate)
+
+- Moving Gemini to the cron — cron doesn't own user API keys; timeout risk,
+  settings staleness, rate-limit management across N users.
+- Hardcoded disqualifier regex in `passesSettingsGate` — wrong, not
+  universal (see decisions table).
+- Raising the storage ceiling to another arbitrary number instead of
+  removing it — pointless on a `TEXT` column.
+- Sleep-based global rate limiting across users in cron — defeats
+  parallelism, doesn't map to real quota boundaries.
+- HEAD+TAIL split for the Gemini window — considered, deferred. The 10k
+  window covers 91% of jobs completely, making the split unnecessary for
+  now. Revisit only if a future cron cycle's data shows systematic misses
+  still occurring past the 10k mark.
+
+## Not yet done (deliberately out of scope here)
+
+- **Detail-page rendering** (`job/[id]/page.tsx`) was never confirmed
+  truncation-free independent of the above — the original handoff doc
+  flagged this as "likely fine, not formally confirmed." Still unconfirmed.
+  Low priority; address opportunistically, not blocking.
+- A regression test asserting a disqualifying signal at position >3000 (or
+  > 10,000) in a long description isn't silently dropped — the original
+  > audit's acceptance criteria asked for this; not added in `6d2d68c`. The
+  > "no hardcoded disqualifier regex" decision above made this less urgent
+  > (there's no longer a position-dependent disqualifier check to regress),
+  > but the broader principle — late-JD content reaching the gates it's
+  > supposed to reach — isn't covered by an explicit test yet.

--- a/scripts/send-salary-reminders.ts
+++ b/scripts/send-salary-reminders.ts
@@ -4,6 +4,11 @@
 // Sends monthly salary update reminders to users whose last report
 // is >28 days old. Run this as a separate cron job (e.g., monthly GitHub Action).
 //
+// Respects each user's `salary_reminder_enabled` setting (separate from
+// `email_alerts_enabled`, which only gates job-match alerts — see
+// docs/plans/2026-06-25-email-toggle-split-and-review-badge.md for why
+// these were split into two toggles).
+//
 // Run with:
 //   pnpm exec tsx scripts/send-salary-reminders.ts
 
@@ -21,6 +26,19 @@ const REMIND_AFTER_DAYS = 28;
 async function run() {
   const cutoff = new Date(Date.now() - REMIND_AFTER_DAYS * 86_400_000).toISOString();
 
+  // Default fallback for users with no user_settings row, or a null value
+  // in it — mirrors lib/settings.ts's resolveUserSettings merge rule for
+  // this field (user value wins when non-null, default otherwise). Can't
+  // reuse resolveUserSettings directly: it calls createServerClient(),
+  // which reads next/headers cookies() and throws outside a request
+  // context — this script runs standalone via tsx, not as a route handler.
+  const { data: defaultRow } = await supabase
+    .from("default_settings")
+    .select("salary_reminder_enabled")
+    .eq("id", 1)
+    .single();
+  const defaultSalaryReminderEnabled = defaultRow?.salary_reminder_enabled ?? true;
+
   // Find most-recent salary report per user where last_updated_at is old
   // and they haven't been reminded in the last 28 days
   const { data: reports, error } = await supabase
@@ -28,7 +46,8 @@ async function run() {
     .select(
       `
       id, user_id, role_title, last_updated_at, reminder_sent_at,
-      user_profiles!inner(email, is_active)
+      user_profiles!inner(email, is_active),
+      user_settings(salary_reminder_enabled)
     `,
     )
     .lt("last_updated_at", cutoff)
@@ -55,6 +74,18 @@ async function run() {
     } | null;
     if (!r.user_id || !profile?.email || !profile.is_active) return false;
     if (seenUsers.has(r.user_id)) return false;
+
+    // Supabase embeds a to-one relation as a one-element array (same shape
+    // fix already applied to AdminUserListItem.user_settings — see audit.md,
+    // Phase 2). A user with no custom row yet (just signed up, never opened
+    // /settings) gets [] here, which falls through to the default.
+    const settingsRow = (r as Record<string, unknown>).user_settings as
+      | { salary_reminder_enabled: boolean | null }[]
+      | null;
+    const salaryReminderEnabled =
+      settingsRow?.[0]?.salary_reminder_enabled ?? defaultSalaryReminderEnabled;
+    if (!salaryReminderEnabled) return false;
+
     seenUsers.add(r.user_id);
     return true;
   });

--- a/src/components/settings/SettingsForm.tsx
+++ b/src/components/settings/SettingsForm.tsx
@@ -30,6 +30,7 @@ export default function SettingsForm() {
   const [global, setGlobal] = useState(true);
   const [allowMid, setAllowMid] = useState(false);
   const [emailAlerts, setEmailAlerts] = useState(true);
+  const [salaryReminders, setSalaryReminders] = useState(true);
   const [prompt, setPrompt] = useState("");
   const [usesDefaults, setUsesDefaults] = useState(true);
   const [skillWeight, setSkillWeight] = useState(60);
@@ -55,6 +56,7 @@ export default function SettingsForm() {
         setGlobal(r.pipeline_global ?? true);
         setAllowMid(r.seniority_allow_mid ?? false);
         setEmailAlerts(r.email_alerts_enabled ?? true);
+        setSalaryReminders(r.salary_reminder_enabled ?? true);
         setPrompt(r.gemini_filter_prompt ?? "");
         setExcludedKeywords((r.excluded_keywords ?? []).join(", "));
         setBlacklistedLocations((r.blacklisted_locations ?? []).join(", "));
@@ -88,6 +90,7 @@ export default function SettingsForm() {
       pipeline_global: global,
       seniority_allow_mid: allowMid,
       email_alerts_enabled: emailAlerts,
+      salary_reminder_enabled: salaryReminders,
       scoring_weights: {
         skill: skillWeight / 100,
         recency: recencyWeight / 100,
@@ -258,7 +261,13 @@ export default function SettingsForm() {
           checked={emailAlerts}
           onChange={setEmailAlerts}
           label="Email me when new matches are found"
-          description="Also includes a monthly reminder to update your salary report"
+          description="Sent after each dashboard refresh that turns up new jobs"
+        />
+        <Toggle
+          checked={salaryReminders}
+          onChange={setSalaryReminders}
+          label="Monthly salary update reminder"
+          description="A nudge to keep your salary report current, sent once a month"
         />
       </Section>
 

--- a/src/lib/__tests__/scoring.test.ts
+++ b/src/lib/__tests__/scoring.test.ts
@@ -62,6 +62,7 @@ const DEFAULT_SETTINGS: ResolvedSettings = {
   ],
   required_keywords: ["react", "next.js", "react native"],
   email_alerts_enabled: true,
+  salary_reminder_enabled: true,
 };
 
 // ── STAFF_KEYWORDS regex (Bug fix: word boundaries on ALL terms) ────

--- a/src/lib/__tests__/settings.test.ts
+++ b/src/lib/__tests__/settings.test.ts
@@ -63,6 +63,7 @@ const DEFAULT_ROW = {
   excluded_keywords: ["backend", "fullstack"],
   blacklisted_locations: ["israel", "us only"],
   required_keywords: ["react", "next.js"],
+  salary_reminder_enabled: true,
   updated_at: "2025-01-01T00:00:00Z",
 };
 
@@ -92,6 +93,7 @@ describe("resolveUserSettings", () => {
     expect(result.expert_skills).toEqual(DEFAULT_ROW.expert_skills);
     expect(result.job_age_days).toBe(7);
     expect(result.gemini_filter_prompt).toBe("Default prompt text");
+    expect(result.salary_reminder_enabled).toBe(true);
   });
 
   it("uses user values when non-null (uses_defaults = false)", async () => {
@@ -109,6 +111,7 @@ describe("resolveUserSettings", () => {
       gemini_filter_prompt: null,
       scoring_weights: null,
       score_denominator: null,
+      salary_reminder_enabled: false, // overridden — independent of email_alerts_enabled
     };
 
     const defaultQuery = mockQuery(DEFAULT_ROW);
@@ -133,6 +136,9 @@ describe("resolveUserSettings", () => {
     expect(result.secondary_skills).toEqual(DEFAULT_ROW.secondary_skills);
     expect(result.pipeline_local).toBe(DEFAULT_ROW.pipeline_local);
     expect(result.gemini_filter_prompt).toBe(DEFAULT_ROW.gemini_filter_prompt);
+
+    // The two email toggles resolve independently of each other
+    expect(result.salary_reminder_enabled).toBe(false); // explicitly overridden
   });
 
   it("normalises scoring weights when they don't sum to 1", async () => {
@@ -191,6 +197,7 @@ describe("resolveUserSettings", () => {
     expect(result.expert_skills).toContain("React");
     expect(result.score_denominator).toBe(18);
     expect(result.scoring_weights.skill).toBeCloseTo(0.6);
+    expect(result.salary_reminder_enabled).toBe(true);
   });
 
   it("saveUserSettings strips role field for security", async () => {

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -41,6 +41,23 @@ const PIPELINE_COLOR: Record<string, string> = {
 
 // ── Job alert email ───────────────────────────────────────────
 
+function reviewBadge(job: ScoredJob): string {
+  // Mirrors JobCard.tsx / job/[id]/page.tsx's badge logic — same two cases,
+  // same copy, inline-styled for email client compatibility. Without this,
+  // a recipient sees a score and a "match" with no indication that Gemini
+  // never actually evaluated the job (no key, or every model hit a quota
+  // error) — the score itself is still real (skill+recency, computed
+  // independently of Gemini), but it hasn't had the semantic sanity check
+  // Gemini provides on top of the keyword/regex gates.
+  if (job.gemini_quota_exhausted) {
+    return `<br><span style="display:inline-block;margin-top:4px;padding:2px 8px;border-radius:999px;background:rgba(245,158,11,0.12);color:#f59e0b;font-size:11px">⚠ Gemini quota exhausted</span>`;
+  }
+  if (!job.gemini_reviewed) {
+    return `<br><span style="display:inline-block;margin-top:4px;padding:2px 8px;border-radius:999px;background:rgba(245,158,11,0.12);color:#f59e0b;font-size:11px">⚠ Not AI-reviewed</span>`;
+  }
+  return "";
+}
+
 function buildJobAlertHtml(jobs: ScoredJob[], recipientEmail: string): string {
   // Group by mode for presentation
   const byMode: Record<string, ScoredJob[]> = {};
@@ -67,6 +84,7 @@ function buildJobAlertHtml(jobs: ScoredJob[], recipientEmail: string): string {
             <span style="font-family:monospace;color:#4ade80;font-size:12px;letter-spacing:1px">
               ${scoreBar(job.total_score)} ${job.total_score}%
             </span>
+            ${reviewBadge(job)}
             ${
               job.matched_skills.length
                 ? `<br><span style="color:#94a3b8;font-size:12px">${job.matched_skills.slice(0, 6).join(" · ")}</span>`

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -144,6 +144,7 @@ const FALLBACK_DEFAULTS: ResolvedSettings = {
   ],
   required_keywords: ["react", "next.js", "react native", "react.js", "reactjs"],
   email_alerts_enabled: true,
+  salary_reminder_enabled: true,
 };
 
 /** Fetch the single default_settings row. Falls back to hardcoded if DB unreachable. */
@@ -209,6 +210,7 @@ export async function resolveUserSettings(userId: string): Promise<ResolvedSetti
       blacklisted_locations: userRow.blacklisted_locations ?? defaults.blacklisted_locations,
       required_keywords: userRow.required_keywords ?? defaults.required_keywords,
       email_alerts_enabled: userRow.email_alerts_enabled ?? defaults.email_alerts_enabled,
+      salary_reminder_enabled: userRow.salary_reminder_enabled ?? defaults.salary_reminder_enabled,
     };
   }
 
@@ -239,6 +241,7 @@ function mergeWithDefaults(
     blacklisted_locations: user?.blacklisted_locations ?? defaults.blacklisted_locations,
     required_keywords: user?.required_keywords ?? defaults.required_keywords,
     email_alerts_enabled: user?.email_alerts_enabled ?? defaults.email_alerts_enabled,
+    salary_reminder_enabled: user?.salary_reminder_enabled ?? defaults.salary_reminder_enabled,
   };
 }
 
@@ -291,6 +294,7 @@ export async function saveUserSettings(
     "blacklisted_locations",
     "required_keywords",
     "email_alerts_enabled",
+    "salary_reminder_enabled",
   ];
 
   for (const key of allowed) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -119,6 +119,7 @@ export interface DefaultSettings {
   blacklisted_locations: string[];
   required_keywords: string[];
   email_alerts_enabled: boolean;
+  salary_reminder_enabled: boolean;
   updated_at: string;
 }
 
@@ -140,6 +141,7 @@ export interface UserSettingsRow {
   blacklisted_locations: string[] | null;
   required_keywords: string[] | null;
   email_alerts_enabled: boolean | null;
+  salary_reminder_enabled: boolean | null;
   updated_at: string;
 }
 
@@ -160,6 +162,7 @@ export interface ResolvedSettings {
   blacklisted_locations: string[];
   required_keywords: string[];
   email_alerts_enabled: boolean;
+  salary_reminder_enabled: boolean;
 }
 
 // ── User Profile ────────────────────────────────────────────


### PR DESCRIPTION
The settings toggle's copy claimed 'Also includes a monthly reminder to
update your salary report,' but scripts/send-salary-reminders.ts never
checked email_alerts_enabled (or any user_settings field) at all -- it
sent to every active user with a stale report, full stop. Anyone who
disabled the toggle to stop job alerts kept getting the monthly nag.

- New salary_reminder_enabled field (DefaultSettings, UserSettingsRow,
  ResolvedSettings), resolved with the same per-field merge rule as
  email_alerts_enabled (user value wins when non-null, default otherwise,
  respected even under uses_defaults).
- SettingsForm.tsx: split the single toggle into two independent ones under
  the same 'Email Alerts' section -- job-match alerts and salary reminders
  are different products (frequent/personalized vs. monthly nudge) and
  shouldn't share one off-switch.
- send-salary-reminders.ts: now embeds user_settings(salary_reminder_enabled)
  and filters on it, falling back to default_settings for users with no
  row yet. Can't reuse resolveUserSettings() here -- it calls
  createServerClient(), which throws outside a request context, and this
  runs standalone via tsx.
- email.ts: alert email now shows the same 'Not AI-reviewed' /
  'Gemini quota exhausted' badge the dashboard and detail page already
  show, instead of presenting every job's score as an equally-vetted match.

Requires a manual schema change (see docs/plans/2026-06-25-email-toggle-
split-and-review-badge.md for the exact SQL) -- this repo doesn't track
Supabase migrations in-repo.

Validation: tsc --noEmit clean, eslint+prettier clean, 77/77 vitest passing
(extended settings.test.ts's existing cases, no new test files -- neither
send-salary-reminders.ts nor email.ts had prior coverage, consistent with
how Bug 4 / FR2 left equivalent pre-existing gaps untouched), next build
successful (30/30 routes). No test added for the script or email.ts --
still tracked as the 'Email path' Playwright smoke test in the Roadmap.