### PR TITLE
fix: surface Supabase errors in domain-counts persistence

### DIFF
--- a/src/lib/__tests__/domain-counts.test.ts
+++ b/src/lib/__tests__/domain-counts.test.ts
@@ -92,4 +92,29 @@ describe("domain_counts persistence", () => {
     // update should NOT have been called (cache was null/empty)
     expect(updateMock).not.toHaveBeenCalled();
   });
+
+  it("logs and returns early when the app_config select fails", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    mockDb.from.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          single: vi.fn().mockResolvedValue({
+            data: null,
+            error: { message: 'relation "app_config" does not exist' },
+          }),
+        }),
+      }),
+    });
+
+    const { loadWorkableStateFromDB } = await import("../sources/ats-utils");
+    await loadWorkableStateFromDB();
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[ats-utils] loadWorkableStateFromDB select failed:",
+      'relation "app_config" does not exist',
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
 });

--- a/src/lib/sources/ats-utils.ts
+++ b/src/lib/sources/ats-utils.ts
@@ -76,9 +76,20 @@ function detectCountry(
 
 let workableBlockedCache: WorkableCooldownEntry[] = [];
 let domainCountsCache: DomainCounts | null = null;
+// Set by loadWorkableStateFromDB() once the app_config row has actually been
+// read. loadDomainCounts() relies on call-order (runner.ts always loads state
+// before any fetch happens) — this flag makes that ordering requirement
+// visible instead of silently returning {} if it's ever violated.
+let stateLoaded = false;
 
 function loadDomainCounts(): DomainCounts {
   if (domainCountsCache) return domainCountsCache;
+  if (!stateLoaded) {
+    console.warn(
+      "[ats-utils] loadDomainCounts() called before loadWorkableStateFromDB() — " +
+        "starting from an empty count. Counts for this run may overwrite persisted history on flush.",
+    );
+  }
   return {};
 }
 
@@ -119,11 +130,16 @@ export function setWorkableBudgetConfig(config: Partial<WorkableBudgetConfig>): 
 export async function loadWorkableStateFromDB(): Promise<void> {
   const { createAdminClient } = await import("@/lib/supabase/admin");
   const db = createAdminClient();
-  const { data } = await db
+  const { data, error } = await db
     .from("app_config")
     .select("workable_blocked, workable_budget, domain_counts")
     .eq("id", 1)
     .single();
+  if (error) {
+    console.error("[ats-utils] loadWorkableStateFromDB select failed:", error.message);
+    return;
+  }
+  stateLoaded = true;
   if (data?.workable_blocked) {
     workableBlockedCache = (data.workable_blocked as unknown as WorkableCooldownEntry[]).filter(
       (e) => new Date(e.until).getTime() > Date.now(),
@@ -144,13 +160,16 @@ export async function flushDomainCountsToDB(): Promise<void> {
   if (!domainCountsCache || Object.keys(domainCountsCache).length === 0) return;
   const { createAdminClient } = await import("@/lib/supabase/admin");
   const db = createAdminClient();
-  await db
+  const { error } = await db
     .from("app_config")
     .update({
       domain_counts: domainCountsCache as unknown as Json,
       updated_at: new Date().toISOString(),
     })
     .eq("id", 1);
+  if (error) {
+    console.error("[ats-utils] flushDomainCountsToDB update failed:", error.message);
+  }
 }
 
 export async function flushWorkable429sToDB(): Promise<void> {
@@ -160,13 +179,16 @@ export async function flushWorkable429sToDB(): Promise<void> {
 
   const { createAdminClient } = await import("@/lib/supabase/admin");
   const db = createAdminClient();
-  await db
+  const { error } = await db
     .from("app_config")
     .update({
       workable_blocked: workableBlockedCache as unknown as Json,
       updated_at: new Date().toISOString(),
     })
     .eq("id", 1);
+  if (error) {
+    console.error("[ats-utils] flushWorkable429sToDB update failed:", error.message);
+  }
 }
 
 function setWorkableBlocked(slug: string, until: Date): void {


### PR DESCRIPTION
- loadWorkableStateFromDB(), flushDomainCountsToDB(), and flushWorkable429sToDB() now destructure and log the Supabase error instead of silently swallowing it (Finding A). A failed select used to leave data null with every if (data?.x) guard quietly no-oping — this would have broken Workable cooldown/budget persistence too, since they share the same select statement.
- loadDomainCounts() now warns if called before loadWorkableStateFromDB() has actually completed, instead of silently returning {} (Finding B). Today this only doesn't happen because runner.ts always loads state first; there was no guard enforcing that ordering.
- Add a test covering the Supabase-error path on the app_config select (Finding C).