### PR TITLE
fix: atomic increment for domain_counts flush

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "test:e2e": "playwright test",
     "test:e2e:report": "playwright show-report",
     "cron": "ts-node -r tsconfig-paths/register --project tsconfig.scripts.json src/scripts/cron.ts",
+    "verify-domain-counts": "ts-node -r tsconfig-paths/register --project tsconfig.scripts.json src/scripts/verify-domain-counts.ts",
+    "verify-domain-counts-coverage": "ts-node -r tsconfig-paths/register --project tsconfig.scripts.json src/scripts/verify-domain-counts-coverage.ts",
     "salary-reminders": "ts-node -r tsconfig-paths/register --project tsconfig.scripts.json scripts/send-salary-reminders.ts",
     "format": "prettier --write .",
     "prepare": "husky"

--- a/src/lib/__tests__/ats-utils-tracking.test.ts
+++ b/src/lib/__tests__/ats-utils-tracking.test.ts
@@ -9,6 +9,7 @@ import type { ATSConfig } from "@/types";
 
 const mockDb = {
   from: vi.fn(),
+  rpc: vi.fn(),
 };
 
 vi.mock("../supabase/admin", () => ({
@@ -24,18 +25,11 @@ const baseCompany: ATSConfig = {
   slug: "acme",
 };
 
-function mockUpdate() {
-  const updateMock = vi.fn().mockReturnValue({
-    eq: vi.fn().mockResolvedValue({ data: null, error: null }),
-  });
-  mockDb.from.mockReturnValue({ update: updateMock });
-  return updateMock;
-}
-
 describe("Teamtailor/Breezy domain_counts tracking", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
+    mockDb.rpc.mockResolvedValue({ data: null, error: null });
   });
 
   afterEach(() => {
@@ -47,15 +41,14 @@ describe("Teamtailor/Breezy domain_counts tracking", () => {
       "fetch",
       vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ data: [] }) }),
     );
-    const updateMock = mockUpdate();
 
     const { fetchTeamtailor, flushDomainCountsToDB } = await import("../sources/ats-utils");
     await fetchTeamtailor(baseCompany, "global", false);
     await flushDomainCountsToDB();
 
-    expect(updateMock).toHaveBeenCalledWith(
-      expect.objectContaining({ domain_counts: { "acme.teamtailor.com": 1 } }),
-    );
+    expect(mockDb.rpc).toHaveBeenCalledWith("increment_domain_counts", {
+      increments: { "acme.teamtailor.com": 1 },
+    });
   });
 
   it("tracks the breezy host via safeFetch instead of bypassing it", async () => {
@@ -63,14 +56,13 @@ describe("Teamtailor/Breezy domain_counts tracking", () => {
       "fetch",
       vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => [] }),
     );
-    const updateMock = mockUpdate();
 
     const { fetchBreezy, flushDomainCountsToDB } = await import("../sources/ats-utils");
     await fetchBreezy({ ...baseCompany, ats: "breezy" }, "global", false);
     await flushDomainCountsToDB();
 
-    expect(updateMock).toHaveBeenCalledWith(
-      expect.objectContaining({ domain_counts: { "acme.breezy.hr": 1 } }),
-    );
+    expect(mockDb.rpc).toHaveBeenCalledWith("increment_domain_counts", {
+      increments: { "acme.breezy.hr": 1 },
+    });
   });
 });

--- a/src/lib/__tests__/domain-counts.test.ts
+++ b/src/lib/__tests__/domain-counts.test.ts
@@ -1,95 +1,112 @@
 // src/lib/__tests__/domain-counts.test.ts
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 // Mock the admin client before importing ats-utils
 const mockDb = {
   from: vi.fn(),
-  select: vi.fn(),
-  update: vi.fn(),
-  eq: vi.fn(),
-  single: vi.fn(),
+  rpc: vi.fn(),
 };
 
 vi.mock("../supabase/admin", () => ({
   createAdminClient: () => mockDb,
 }));
 
-describe("domain_counts persistence", () => {
+function mockSelect(data: { workable_blocked: unknown; workable_budget: unknown }) {
+  mockDb.from.mockReturnValue({
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        single: vi.fn().mockResolvedValue({ data, error: null }),
+      }),
+    }),
+  });
+}
+
+describe("domain_counts persistence (atomic increment)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({}) }),
+    );
   });
 
-  it("loads domain_counts from app_config on startup", async () => {
-    const testCounts = { "example.com": 5, "test.io": 3 };
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
 
-    mockDb.from.mockReturnValue({
-      select: vi.fn().mockReturnValue({
-        eq: vi.fn().mockReturnValue({
-          single: vi.fn().mockResolvedValue({
-            data: {
-              workable_blocked: null,
-              workable_budget: null,
-              domain_counts: testCounts,
-            },
-            error: null,
-          }),
-        }),
-      }),
-    });
+  it("no longer selects or loads domain_counts on startup", async () => {
+    mockSelect({ workable_blocked: null, workable_budget: null });
 
     const { loadWorkableStateFromDB } = await import("../sources/ats-utils");
     await loadWorkableStateFromDB();
 
-    // Verify the SELECT was made with domain_counts
+    // Regression guard for the double-count bug: domain_counts must never be
+    // read into the in-memory delta cache, since flushDomainCountsToDB() now
+    // ADDS that cache onto the DB's existing value via an atomic RPC. If this
+    // were ever re-seeded from the DB, every flush would add the old total
+    // back on top of itself.
     expect(mockDb.from).toHaveBeenCalledWith("app_config");
     const selectFn = mockDb.from.mock.results[0].value.select;
-    expect(selectFn).toHaveBeenCalledWith("workable_blocked, workable_budget, domain_counts");
+    expect(selectFn).toHaveBeenCalledWith("workable_blocked, workable_budget");
   });
 
-  it("returns empty object when domain_counts is null in DB", async () => {
-    mockDb.from.mockReturnValue({
-      select: vi.fn().mockReturnValue({
-        eq: vi.fn().mockReturnValue({
-          single: vi.fn().mockResolvedValue({
-            data: { workable_blocked: null, workable_budget: null, domain_counts: null },
-            error: null,
-          }),
-        }),
-      }),
-    });
+  it("skips flush when nothing was tracked this run", async () => {
+    const { flushDomainCountsToDB } = await import("../sources/ats-utils");
 
-    const { loadWorkableStateFromDB } = await import("../sources/ats-utils");
-    await loadWorkableStateFromDB();
-
-    // Load succeeded without error
-    expect(mockDb.from).toHaveBeenCalledTimes(1);
-  });
-
-  it("skips flush when domain_counts cache is empty", async () => {
-    const updateMock = vi.fn().mockReturnValue({
-      eq: vi.fn().mockResolvedValue({ data: null, error: null }),
-    });
-
-    mockDb.from.mockReturnValue({
-      select: vi.fn().mockReturnValue({
-        eq: vi.fn().mockReturnValue({
-          single: vi.fn().mockResolvedValue({
-            data: { workable_blocked: null, workable_budget: null, domain_counts: null },
-            error: null,
-          }),
-        }),
-      }),
-      update: updateMock,
-    });
-
-    const { loadWorkableStateFromDB, flushDomainCountsToDB } = await import("../sources/ats-utils");
-    await loadWorkableStateFromDB();
-
-    // Flush with empty cache should be a no-op (no update call)
     await flushDomainCountsToDB();
 
-    // update should NOT have been called (cache was null/empty)
-    expect(updateMock).not.toHaveBeenCalled();
+    expect(mockDb.rpc).not.toHaveBeenCalled();
+  });
+
+  it("sends only this run's delta to increment_domain_counts, never a pre-loaded baseline", async () => {
+    mockSelect({ workable_blocked: null, workable_budget: null });
+    mockDb.rpc.mockResolvedValue({ data: null, error: null });
+
+    const { loadWorkableStateFromDB, flushDomainCountsToDB, safeFetch } =
+      await import("../sources/ats-utils");
+
+    await loadWorkableStateFromDB();
+
+    await safeFetch("https://boards.greenhouse.io/foo");
+    await safeFetch("https://boards.greenhouse.io/bar");
+    await safeFetch("https://jobs.lever.co/baz");
+
+    await flushDomainCountsToDB();
+
+    expect(mockDb.rpc).toHaveBeenCalledWith("increment_domain_counts", {
+      increments: { "boards.greenhouse.io": 2, "jobs.lever.co": 1 },
+    });
+  });
+
+  it("resets the in-memory delta after a successful flush so a warm process doesn't resend it", async () => {
+    mockDb.rpc.mockResolvedValue({ data: null, error: null });
+    const { flushDomainCountsToDB, safeFetch } = await import("../sources/ats-utils");
+
+    await safeFetch("https://boards.greenhouse.io/foo");
+    await flushDomainCountsToDB();
+    await flushDomainCountsToDB(); // same warm process, nothing new tracked since
+
+    expect(mockDb.rpc).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the unflushed delta on rpc error so a later flush can still send it", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockDb.rpc
+      .mockResolvedValueOnce({ data: null, error: { message: "connection reset" } })
+      .mockResolvedValueOnce({ data: null, error: null });
+
+    const { flushDomainCountsToDB, safeFetch } = await import("../sources/ats-utils");
+
+    await safeFetch("https://boards.greenhouse.io/foo");
+    await flushDomainCountsToDB(); // fails — must not clear the cache
+    await flushDomainCountsToDB(); // retry — should still include the same delta
+
+    expect(mockDb.rpc).toHaveBeenCalledTimes(2);
+    expect(mockDb.rpc).toHaveBeenNthCalledWith(2, "increment_domain_counts", {
+      increments: { "boards.greenhouse.io": 1 },
+    });
+
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -507,7 +507,12 @@ export type Database = {
       };
     };
     Views: Record<string, never>;
-    Functions: Record<string, never>;
+    Functions: {
+      increment_domain_counts: {
+        Args: { increments: Json };
+        Returns: undefined;
+      };
+    };
     Enums: Record<string, never>;
     CompositeTypes: Record<string, never>;
   };

--- a/src/lib/sources/ats-utils.ts
+++ b/src/lib/sources/ats-utils.ts
@@ -75,6 +75,13 @@ function detectCountry(
 // ── Helpers ────────────────────────────────────────────────────────────────
 
 let workableBlockedCache: WorkableCooldownEntry[] = [];
+// Holds ONLY this run's not-yet-flushed increments — NOT the full historical
+// total. flushDomainCountsToDB() adds these onto the DB's existing value via
+// an atomic Postgres function (increment_domain_counts), so this cache must
+// never be seeded from the DB's current value, or every flush would
+// double-count the baseline on top of itself. Reset to null after a
+// successful flush so a warm/reused process doesn't resend an already-
+// persisted delta on its next run.
 let domainCountsCache: DomainCounts | null = null;
 
 function loadDomainCounts(): DomainCounts {
@@ -121,7 +128,7 @@ export async function loadWorkableStateFromDB(): Promise<void> {
   const db = createAdminClient();
   const { data } = await db
     .from("app_config")
-    .select("workable_blocked, workable_budget, domain_counts")
+    .select("workable_blocked, workable_budget")
     .eq("id", 1)
     .single();
   if (data?.workable_blocked) {
@@ -135,22 +142,25 @@ export async function loadWorkableStateFromDB(): Promise<void> {
       ...(data.workable_budget as Partial<WorkableBudgetConfig>),
     };
   }
-  if (data?.domain_counts) {
-    domainCountsCache = data.domain_counts as unknown as DomainCounts;
-  }
 }
 
 export async function flushDomainCountsToDB(): Promise<void> {
   if (!domainCountsCache || Object.keys(domainCountsCache).length === 0) return;
   const { createAdminClient } = await import("@/lib/supabase/admin");
   const db = createAdminClient();
-  await db
-    .from("app_config")
-    .update({
-      domain_counts: domainCountsCache as unknown as Json,
-      updated_at: new Date().toISOString(),
-    })
-    .eq("id", 1);
+  // Atomic server-side add via increment_domain_counts(increments) instead of
+  // a read-modify-write .update() — see the function comment in the
+  // migration SQL for why a blind overwrite loses updates when two cron runs
+  // overlap. domainCountsCache here is ONLY this run's delta (see comment on
+  // its declaration), which is exactly what an additive RPC needs.
+  const { error } = await db.rpc("increment_domain_counts", {
+    increments: domainCountsCache as unknown as Json,
+  });
+  if (error) {
+    console.error("[ats-utils] flushDomainCountsToDB rpc failed:", error.message);
+    return; // keep the unflushed delta around so a retry on a warm process can still send it
+  }
+  domainCountsCache = null;
 }
 
 export async function flushWorkable429sToDB(): Promise<void> {

--- a/src/lib/sources/ats-utils.ts
+++ b/src/lib/sources/ats-utils.ts
@@ -94,7 +94,9 @@ function loadDomainCounts(): DomainCounts {
   if (!stateLoaded) {
     console.warn(
       "[ats-utils] loadDomainCounts() called before loadWorkableStateFromDB() — " +
-        "starting from an empty count. Counts for this run may overwrite persisted history on flush.",
+        "starting this run's delta from zero. Harmless for domain_counts itself " +
+        "(the flush is additive, not an overwrite), but it means Workable cooldown/" +
+        "budget state wasn't loaded either, since both share this same load step.",
     );
   }
   return {};
@@ -164,16 +166,19 @@ export async function flushDomainCountsToDB(): Promise<void> {
   if (!domainCountsCache || Object.keys(domainCountsCache).length === 0) return;
   const { createAdminClient } = await import("@/lib/supabase/admin");
   const db = createAdminClient();
-  const { error } = await db
-    .from("app_config")
-    .update({
-      domain_counts: domainCountsCache as unknown as Json,
-      updated_at: new Date().toISOString(),
-    })
-    .eq("id", 1);
+  // Atomic server-side add via increment_domain_counts(increments) instead of
+  // a read-modify-write .update() — see the function comment in the
+  // migration SQL for why a blind overwrite loses updates when two cron runs
+  // overlap. domainCountsCache here is ONLY this run's delta (see comment on
+  // its declaration), which is exactly what an additive RPC needs.
+  const { error } = await db.rpc("increment_domain_counts", {
+    increments: domainCountsCache as unknown as Json,
+  });
   if (error) {
-    console.error("[ats-utils] flushDomainCountsToDB update failed:", error.message);
+    console.error("[ats-utils] flushDomainCountsToDB rpc failed:", error.message);
+    return; // keep the unflushed delta around so a retry on a warm process can still send it
   }
+  domainCountsCache = null;
 }
 
 export async function flushWorkable429sToDB(): Promise<void> {

--- a/src/scripts/verify-domain-counts-coverage.ts
+++ b/src/scripts/verify-domain-counts-coverage.ts
@@ -1,0 +1,143 @@
+// src/scripts/verify-domain-counts-coverage.ts
+// Entry point: npx ts-node -r tsconfig-paths/register --project tsconfig.scripts.json src/scripts/verify-domain-counts-coverage.ts
+//
+// Runs the real fetch step against every active company in public.ats_companies
+// — same fetchCompany() dispatch runner.ts uses — but does NOT upsert into
+// raw_jobs and does NOT send any emails. The only side effect on Supabase is
+// the same domain_counts flush a normal cron run would do.
+//
+// Use this to confirm which ATS hosts actually get tracked. In particular:
+// before fix/track-teamtailor-breezy-requests, *.teamtailor.com and
+// *.breezy.hr never appear here even when active companies use them, because
+// those two fetchers bypass safeFetch() entirely. After the fix, they should.
+//
+// Takes a few minutes — this makes a real network call to every active ATS
+// endpoint, same as a production cron run.
+//
+// NOTE: this script was referenced in the original PR #28 review brief but
+// was never committed to the repo — recreated here from that description.
+
+import { config } from "dotenv";
+import path from "path";
+
+config({ path: path.resolve(process.cwd(), ".env.local") });
+
+import { createAdminClient } from "../lib/supabase/admin";
+import { fetchCompany } from "../lib/ats-bridge";
+import { loadWorkableStateFromDB, flushDomainCountsToDB } from "../lib/sources/ats-utils";
+import type { ATSCompanyRow } from "../lib/types";
+
+const CONCURRENCY_LIMIT = 8;
+
+async function withConcurrencyLimit<T>(
+  tasks: Array<() => Promise<T>>,
+  limit: number,
+): Promise<T[]> {
+  const results: T[] = [];
+  const executing: Promise<void>[] = [];
+  for (const task of tasks) {
+    const p = task().then((r) => {
+      results.push(r);
+    });
+    executing.push(p);
+    if (executing.length >= limit) {
+      await Promise.race(executing);
+      for (let i = executing.length - 1; i >= 0; i--) {
+        const state = await Promise.race([
+          executing[i].then(() => "done").catch(() => "done"),
+          Promise.resolve("pending"),
+        ]);
+        if (state === "done") executing.splice(i, 1);
+      }
+    }
+  }
+  await Promise.allSettled(executing);
+  return results;
+}
+
+(async () => {
+  const db = createAdminClient();
+
+  console.log("[verify-coverage] Reading domain_counts baseline...");
+  const { data: before } = await db.from("app_config").select("domain_counts").eq("id", 1).single();
+  const baseline = (before?.domain_counts as Record<string, number> | null) ?? {};
+
+  console.log("[verify-coverage] Loading active companies...");
+  const { data: companies, error } = await db
+    .from("ats_companies")
+    .select("*")
+    .eq("is_active", true);
+  if (error || !companies?.length) {
+    console.error(
+      "[verify-coverage] Could not load active companies:",
+      error?.message ?? "none found",
+    );
+    process.exit(1);
+  }
+
+  await loadWorkableStateFromDB();
+
+  const byAts = new Map<string, number>();
+  for (const row of companies as ATSCompanyRow[]) {
+    byAts.set(row.ats, (byAts.get(row.ats) ?? 0) + 1);
+  }
+  console.log("[verify-coverage] Active companies by ATS:");
+  for (const [ats, count] of byAts) console.log(`  ${ats}: ${count}`);
+
+  const tasks: Array<() => Promise<{ company: string; ats: string; error: string | null }>> = [];
+  for (const row of companies as ATSCompanyRow[]) {
+    const mode = row.pipeline_visa
+      ? ("visa" as const)
+      : row.pipeline_local
+        ? ("local" as const)
+        : ("global" as const);
+    tasks.push(async () => {
+      const result = await fetchCompany(row, mode);
+      return { company: row.name, ats: row.ats, error: result.error };
+    });
+  }
+
+  console.log(`\n[verify-coverage] Fetching ${tasks.length} companies (no upserts, no emails)...`);
+  const results = await withConcurrencyLimit(tasks, CONCURRENCY_LIMIT);
+  const failed = results.filter((r) => r.error);
+  console.log(`  done — ${results.length - failed.length} ok, ${failed.length} errored`);
+
+  console.log("\n[verify-coverage] Flushing domain_counts...");
+  await flushDomainCountsToDB();
+
+  const { data: after } = await db.from("app_config").select("domain_counts").eq("id", 1).single();
+  const updated = (after?.domain_counts as Record<string, number> | null) ?? {};
+
+  console.log("\n[verify-coverage] Hosts tracked this run (delta since baseline):");
+  const allHosts = new Set([...Object.keys(baseline), ...Object.keys(updated)]);
+  let trackedAny = false;
+  for (const host of Array.from(allHosts).sort()) {
+    const delta = (updated[host] ?? 0) - (baseline[host] ?? 0);
+    if (delta > 0) {
+      trackedAny = true;
+      console.log(`  ${host}: +${delta} (total ${updated[host]})`);
+    }
+  }
+  if (!trackedAny) {
+    console.log("  (none — nothing was tracked this run)");
+  }
+
+  const teamtailorActive = (companies as ATSCompanyRow[]).some((c) => c.ats === "teamtailor");
+  const breezyActive = (companies as ATSCompanyRow[]).some((c) => c.ats === "breezy");
+  const teamtailorTracked = Array.from(allHosts).some(
+    (h) => h.endsWith(".teamtailor.com") && (updated[h] ?? 0) - (baseline[h] ?? 0) > 0,
+  );
+  const breezyTracked = Array.from(allHosts).some(
+    (h) => h.endsWith(".breezy.hr") && (updated[h] ?? 0) - (baseline[h] ?? 0) > 0,
+  );
+
+  console.log("\n[verify-coverage] Teamtailor/Breezy check:");
+  console.log(
+    `  Teamtailor: ${teamtailorActive ? "active companies present" : "no active companies"} — ${teamtailorTracked ? "TRACKED ✓" : "not tracked"}`,
+  );
+  console.log(
+    `  Breezy:     ${breezyActive ? "active companies present" : "no active companies"} — ${breezyTracked ? "TRACKED ✓" : "not tracked"}`,
+  );
+
+  process.exit(0);
+})();

--- a/src/scripts/verify-domain-counts.ts
+++ b/src/scripts/verify-domain-counts.ts
@@ -1,0 +1,106 @@
+// src/scripts/verify-domain-counts.ts
+// Entry point: npx ts-node -r tsconfig-paths/register --project tsconfig.scripts.json src/scripts/verify-domain-counts.ts
+//
+// Round-trips a handful of increments through Supabase's
+// increment_domain_counts() RPC and confirms:
+//   1. A flush actually persists the count (basic round-trip).
+//   2. A second flush with nothing newly tracked does NOT change the value
+//      again (regression check for Finding D: domain_counts must never be
+//      double-counted by re-sending an already-flushed delta).
+//   3. The increment is additive on top of whatever's already there, not a
+//      blind overwrite (proves the atomic-increment fix actually works).
+//
+// Uses a sentinel host on the reserved `.invalid` TLD (RFC 2606) so this
+// never makes a real network request and never pollutes the real per-ATS
+// counts shown on the admin page. Cleans its own sentinel key back to its
+// starting value when done, pass or fail.
+//
+// NOTE: this script was referenced in the original PR #28 review brief but
+// was never committed to the repo — recreated here from that description.
+
+import { config } from "dotenv";
+import path from "path";
+
+config({ path: path.resolve(process.cwd(), ".env.local") });
+
+import { createAdminClient } from "../lib/supabase/admin";
+import {
+  loadWorkableStateFromDB,
+  flushDomainCountsToDB,
+  safeFetch,
+} from "../lib/sources/ats-utils";
+
+const SENTINEL_HOST = "job-radar-verify.invalid";
+const SENTINEL_URL = `https://${SENTINEL_HOST}/ping`;
+
+async function readSentinelCount(): Promise<number> {
+  const db = createAdminClient();
+  const { data, error } = await db.from("app_config").select("domain_counts").eq("id", 1).single();
+  if (error) throw new Error(`Could not read app_config: ${error.message}`);
+  const counts = (data?.domain_counts as Record<string, number> | null) ?? {};
+  return counts[SENTINEL_HOST] ?? 0;
+}
+
+async function cleanup(totalAdded: number): Promise<void> {
+  if (totalAdded === 0) return;
+  const db = createAdminClient();
+  const { error } = await db.rpc("increment_domain_counts", {
+    increments: { [SENTINEL_HOST]: -totalAdded },
+  });
+  if (error) {
+    console.warn(
+      `[verify-domain-counts] cleanup failed — sentinel key "${SENTINEL_HOST}" left at +${totalAdded} in app_config.domain_counts. Safe to ignore or zero out manually.`,
+      error.message,
+    );
+  }
+}
+
+(async () => {
+  let added = 0;
+  try {
+    console.log("[verify-domain-counts] Reading baseline...");
+    const baseline = await readSentinelCount();
+    console.log(`  baseline domain_counts["${SENTINEL_HOST}"] = ${baseline}`);
+
+    console.log("[verify-domain-counts] Loading Workable state (required before tracking)...");
+    await loadWorkableStateFromDB();
+
+    console.log("[verify-domain-counts] Tracking 3 sentinel requests + flushing...");
+    await safeFetch(SENTINEL_URL);
+    await safeFetch(SENTINEL_URL);
+    await safeFetch(SENTINEL_URL);
+    await flushDomainCountsToDB();
+    added += 3;
+
+    const afterFirstFlush = await readSentinelCount();
+    const firstDelta = afterFirstFlush - baseline;
+    if (firstDelta !== 3) {
+      throw new Error(
+        `Expected +3 after first flush, got +${firstDelta} (baseline ${baseline} -> ${afterFirstFlush}). ` +
+          `If this is +6 or more, the flush is double-counting — domain_counts is being re-seeded from the DB ` +
+          `as a baseline instead of staying delta-only.`,
+      );
+    }
+    console.log(`  ✓ first flush: +${firstDelta} (expected +3)`);
+
+    console.log("[verify-domain-counts] Flushing again with nothing newly tracked...");
+    await flushDomainCountsToDB();
+    const afterSecondFlush = await readSentinelCount();
+    if (afterSecondFlush !== afterFirstFlush) {
+      throw new Error(
+        `Expected no change on a flush with nothing tracked, but went ${afterFirstFlush} -> ${afterSecondFlush}. ` +
+          `The in-memory delta cache isn't being reset after a successful flush — a warm process would resend ` +
+          `an already-persisted delta on every subsequent run.`,
+      );
+    }
+    console.log(`  ✓ second flush: no change (still ${afterSecondFlush})`);
+
+    console.log("\n[verify-domain-counts] PASS — atomic increment round-trips correctly.\n");
+    await cleanup(added);
+    process.exit(0);
+  } catch (err) {
+    console.error("\n[verify-domain-counts] FAIL:", err instanceof Error ? err.message : err);
+    await cleanup(added);
+    process.exit(1);
+  }
+})();

--- a/supabase/migrations/20260627_increment_domain_counts.sql
+++ b/supabase/migrations/20260627_increment_domain_counts.sql
@@ -1,0 +1,36 @@
+-- Run this manually in the Supabase SQL editor (Dashboard → SQL Editor).
+-- This repo doesn't have the Supabase CLI / migrations wired up yet, so
+-- there's no automated path to apply this — it's not picked up by any
+-- build or deploy step.
+--
+-- Backs Finding D (fix/atomic-domain-counts-flush): replaces the app-side
+-- read-modify-write in flushDomainCountsToDB() with a single atomic UPDATE,
+-- so two overlapping cron runs add their counts instead of one silently
+-- clobbering the other's increments.
+--
+-- NOTE on the brief's suggested version of this function: it built the
+-- result via `jsonb_object_agg(key, ...) FROM jsonb_object_keys(increments)`,
+-- which only emits keys present in `increments`. That silently DROPS every
+-- existing host in domain_counts that wasn't fetched in the current run —
+-- a real data-loss bug, not just a style nit. This version unions the key
+-- sets (existing ∪ incoming) via `coalesce(domain_counts, '{}') || increments`
+-- so untouched hosts are carried forward unchanged.
+create or replace function public.increment_domain_counts(increments jsonb)
+returns void
+language sql
+set search_path = ''
+as $$
+  update public.app_config as t
+  set domain_counts = (
+    select jsonb_object_agg(
+      key,
+      coalesce((t.domain_counts ->> key)::bigint, 0) + coalesce((increments ->> key)::bigint, 0)
+    )
+    from jsonb_object_keys(coalesce(t.domain_counts, '{}'::jsonb) || increments) as key
+  ),
+  updated_at = now()
+  where t.id = 1;
+$$;
+
+comment on function public.increment_domain_counts(jsonb) is
+  'Atomically adds each {host: count} pair in `increments` onto app_config.domain_counts (id=1), preserving any existing host not present in this call. Used by flushDomainCountsToDB() in src/lib/sources/ats-utils.ts so overlapping cron runs add instead of overwrite.';


### PR DESCRIPTION
Finding D: flushDomainCountsToDB() did a read-modify-write (.update() with the full object) — two overlapping cron runs would race, and whichever flushed last silently dropped the other run's increments.

- Add increment_domain_counts(jsonb) Postgres function (supabase/migrations/20260627_increment_domain_counts.sql, run manually in the Supabase SQL editor — no migration tooling wired up in this repo yet) that adds each {host: count} pair onto app_config.domain_counts atomically, unioning keys so untouched hosts are preserved. Note: the brief's suggested version of this function only emitted keys present in the increments argument, which would have silently dropped every host not touched in the current run — fixed here by unioning the existing and incoming key sets instead.
- flushDomainCountsToDB() now calls that RPC instead of .update().
- Necessary correctness change beyond the RPC swap itself: loadWorkableStateFromDB() no longer seeds domainCountsCache from the DB's existing domain_counts. Under additive semantics the in-memory cache must hold ONLY this run's not-yet-flushed delta — seeding it with the historical total would double-count that baseline on every single flush. domainCountsCache now resets to null after a successful flush (so a warm/reused serverless invocation doesn't resend an already-persisted delta), and stays populated on a failed flush so a retry can still send it.
- database.types.ts: type the new RPC under Functions (was Record<string, never>) so .rpc() doesn't need an any-cast — see AGENTS.md's no-any rule.
- Rewrite domain-counts.test.ts for the new behavior: confirms domain_counts is never loaded as a baseline, confirms only the run's delta is sent to the RPC, confirms the cache resets after a successful flush, and confirms a failed flush keeps the delta for a retry.
- Recreate the two verify-domain-counts*.ts scripts referenced in the review brief (not present anywhere in this repo's git history — likely local-only from the original review session). Not run against production here; no Supabase credentials in this environment.