### PR TITLE
feat: track Teamtailor/Breezy requests via safeFetch

### DIFF
--- a/src/lib/__tests__/ats-utils-tracking.test.ts
+++ b/src/lib/__tests__/ats-utils-tracking.test.ts
@@ -1,0 +1,76 @@
+// src/lib/__tests__/ats-utils-tracking.test.ts
+// Regression guard for Finding E (feat/track-teamtailor-breezy-requests):
+// fetchTeamtailor() and fetchBreezy() used to call raw fetch() directly,
+// which meant they were invisible in domain_counts and had no rate-limiting
+// of any kind, unlike every other ATS fetcher. This confirms both now route
+// through safeFetch() and get tracked like the rest.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ATSConfig } from "@/types";
+
+const mockDb = {
+  from: vi.fn(),
+};
+
+vi.mock("../supabase/admin", () => ({
+  createAdminClient: () => mockDb,
+}));
+
+const baseCompany: ATSConfig = {
+  name: "Acme",
+  country: "Egypt",
+  countryFlag: "🇪🇬",
+  city: "Cairo",
+  ats: "teamtailor",
+  slug: "acme",
+};
+
+function mockUpdate() {
+  const updateMock = vi.fn().mockReturnValue({
+    eq: vi.fn().mockResolvedValue({ data: null, error: null }),
+  });
+  mockDb.from.mockReturnValue({ update: updateMock });
+  return updateMock;
+}
+
+describe("Teamtailor/Breezy domain_counts tracking", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("tracks the teamtailor host via safeFetch instead of bypassing it", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ data: [] }) }),
+    );
+    const updateMock = mockUpdate();
+
+    const { fetchTeamtailor, flushDomainCountsToDB } = await import("../sources/ats-utils");
+    await fetchTeamtailor(baseCompany, "global", false);
+    await flushDomainCountsToDB();
+
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ domain_counts: { "acme.teamtailor.com": 1 } }),
+    );
+  });
+
+  it("tracks the breezy host via safeFetch instead of bypassing it", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => [] }),
+    );
+    const updateMock = mockUpdate();
+
+    const { fetchBreezy, flushDomainCountsToDB } = await import("../sources/ats-utils");
+    await fetchBreezy({ ...baseCompany, ats: "breezy" }, "global", false);
+    await flushDomainCountsToDB();
+
+    expect(updateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ domain_counts: { "acme.breezy.hr": 1 } }),
+    );
+  });
+});

--- a/src/lib/sources/ats-utils.ts
+++ b/src/lib/sources/ats-utils.ts
@@ -208,13 +208,18 @@ export function stripHtml(html: string): string {
 }
 
 /** Increased timeout to 45s to avoid AbortErrors under load */
-export async function safeFetch(url: string, timeout = 45_000): Promise<Response | null> {
+export async function safeFetch(
+  url: string,
+  timeout = 45_000,
+  extraHeaders?: Record<string, string>,
+): Promise<Response | null> {
   trackDomainRequest(url);
   try {
     return await fetch(url, {
       headers: {
         "User-Agent":
           "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        ...extraHeaders,
       },
       signal: AbortSignal.timeout(timeout),
     });
@@ -625,10 +630,7 @@ export async function fetchTeamtailor(
 ): Promise<FetcherResult> {
   const t0 = Date.now();
   const publicUrl = `https://${c.slug}.teamtailor.com/jobs.json`;
-  const res = await fetch(publicUrl, {
-    headers: { "User-Agent": "Mozilla/5.0", Accept: "application/json" },
-    signal: AbortSignal.timeout(30_000),
-  }).catch(() => null);
+  const res = await safeFetch(publicUrl, 30_000, { Accept: "application/json" });
 
   if (!res)
     return {
@@ -683,10 +685,7 @@ export async function fetchBreezy(
 ): Promise<FetcherResult> {
   const t0 = Date.now();
   const url = `https://${c.slug}.breezy.hr/json`;
-  const res = await fetch(url, {
-    headers: { "User-Agent": "Mozilla/5.0", Accept: "application/json" },
-    signal: AbortSignal.timeout(30_000),
-  }).catch(() => null);
+  const res = await safeFetch(url, 30_000, { Accept: "application/json" });
 
   if (!res)
     return {


### PR DESCRIPTION
Finding E: fetchTeamtailor() and fetchBreezy() called raw fetch() directly instead of safeFetch(), so they never showed up in domain_counts and have no rate-limiting of any kind — unlike every other ATS fetcher (Workable is the one deliberate exception; it has its own dedicated cooldown/budget system, untouched here). Confirmed via a real run against all 266 active companies: Teamtailor (2 active companies) and Breezy (6 active companies) never appeared in the tracked hosts despite being fetched.

- safeFetch() now takes an optional extraHeaders param so callers that need a header it doesn't set by default (here, Accept: application/json) don't have to bypass it and call raw fetch() to get that header.
- fetchTeamtailor() and fetchBreezy() now go through safeFetch() with that header, instead of duplicating the request manually.
- Add a regression test exercising both fetchers end-to-end against a mocked global fetch, confirming their hosts now land in domain_counts. Verified these fail against the pre-fix code (0 calls) and pass after.

Out of scope, per the brief: whether Teamtailor/Breezy need Workable-style budget/cooldown handling too — that's a separate decision once real request volume is visible from this fix.

Not run against production: verify-domain-counts-coverage.ts (added on fix/atomic-domain-counts-flush) would confirm *.teamtailor.com and *.breezy.hr show up in a real run, but this sandbox has no Supabase credentials and no network path to those ATS hosts.