### PR TITLE
Fix/ats-rate-limiting-issue-52

### DIFF
--- a/src/lib/__tests__/ats-utils-rate-limit.test.ts
+++ b/src/lib/__tests__/ats-utils-rate-limit.test.ts
@@ -1,0 +1,110 @@
+// src/lib/__tests__/ats-utils-rate-limit.test.ts
+// Regression guard for issue #52 (ATS 429s): safeFetch() used to fire every
+// request the instant it was called, with no host awareness and no retry.
+// A burst of companies on the same shared-host ATS (Greenhouse, Lever,
+// Ashby, SmartRecruiters) could all hit that host simultaneously — the
+// exact pattern that trips a shared API's rate limiter. These tests prove
+// the fix mechanically instead of relying on a live cron run against a
+// real ATS to "probably" show fewer 429s.
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+describe("safeFetch rate-limit handling", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("retries on 429 and returns the eventual successful response", async () => {
+    let calls = 0;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(() => {
+        calls += 1;
+        if (calls === 1) {
+          return Promise.resolve({ status: 429, ok: false, headers: new Headers() });
+        }
+        return Promise.resolve({
+          status: 200,
+          ok: true,
+          headers: new Headers(),
+          json: async () => ({}),
+        });
+      }),
+    );
+
+    const { safeFetch } = await import("../sources/ats-utils");
+    const res = await safeFetch("https://boards-api.greenhouse.io/v1/boards/acme/jobs");
+
+    expect(calls).toBe(2); // first call 429'd, second (retry) succeeded
+    expect(res?.status).toBe(200);
+  });
+
+  it("gives up after MAX_429_RETRIES instead of retrying forever", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ status: 429, ok: false, headers: new Headers() }),
+    );
+
+    const { safeFetch } = await import("../sources/ats-utils");
+    const res = await safeFetch("https://boards-api.greenhouse.io/v1/boards/always-429/jobs");
+
+    // 1 initial attempt + MAX_429_RETRIES(2) retries = 3 total calls, then give up.
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(3);
+    expect(res?.status).toBe(429);
+  }, 20_000); // exponential backoff (2s + 4s) exceeds vitest's default 5s test timeout
+
+  it("staggers concurrent requests to the same host instead of firing them all at once", async () => {
+    const callTimestamps: number[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(() => {
+        callTimestamps.push(Date.now());
+        return Promise.resolve({
+          status: 200,
+          ok: true,
+          headers: new Headers(),
+          json: async () => ({}),
+        });
+      }),
+    );
+
+    const { safeFetch } = await import("../sources/ats-utils");
+    const host = "boards-api.greenhouse.io";
+
+    // Simulates the exact scenario that caused issue #52: several companies
+    // on the same ATS host, all kicked off by the runner at once.
+    await Promise.all(
+      Array.from({ length: 5 }, (_, i) => safeFetch(`https://${host}/v1/boards/company-${i}/jobs`)),
+    );
+
+    expect(callTimestamps).toHaveLength(5);
+    const spread = Math.max(...callTimestamps) - Math.min(...callTimestamps);
+    // Old behavior: all 5 fire within ~0ms of each other. New behavior: each
+    // queued request waits 200-600ms behind the previous one on that host,
+    // so 5 requests should span at least ~4 stagger intervals.
+    expect(spread).toBeGreaterThan(400);
+  });
+
+  it("does not make unrelated hosts wait behind a different host's queue", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        status: 200,
+        ok: true,
+        headers: new Headers(),
+        json: async () => ({}),
+      }),
+    );
+
+    const { safeFetch } = await import("../sources/ats-utils");
+
+    const start = Date.now();
+    await safeFetch("https://boards-api.greenhouse.io/v1/boards/acme/jobs");
+    await safeFetch("https://api.lever.co/v0/postings/other-co");
+    const elapsed = Date.now() - start;
+
+    // Two different hosts, run sequentially here — each pays its own stagger
+    // (max 600ms) but they don't compound into one shared queue's delay.
+    expect(elapsed).toBeLessThan(1500);
+  });
+});

--- a/src/lib/sources/ats-utils.ts
+++ b/src/lib/sources/ats-utils.ts
@@ -236,6 +236,38 @@ export function stripHtml(html: string): string {
     .trim();
 }
 
+// Per-host request queue. Greenhouse, Lever, Ashby, and SmartRecruiters each
+// serve every company from a single shared host (e.g. boards-api.greenhouse.io),
+// but the runner's concurrency limit (8) has no host awareness — 8 companies
+// on the same ATS could previously fire simultaneously with zero stagger,
+// which is exactly the pattern that trips a shared API's rate limiter.
+// This staggers requests to the same host and, on a 429, backs off and
+// retries instead of just giving up for the rest of the run.
+const hostQueues = new Map<string, Promise<unknown>>();
+const HOST_STAGGER_MS = [200, 400, 600];
+const MAX_429_RETRIES = 2;
+
+function queueByHost<T>(host: string, fn: () => Promise<T>): Promise<T> {
+  const stagger = HOST_STAGGER_MS[Math.floor(Math.random() * HOST_STAGGER_MS.length)];
+  const prev = hostQueues.get(host) ?? Promise.resolve();
+  const result = prev.then(() => new Promise((r) => setTimeout(r, stagger))).then(fn);
+  hostQueues.set(
+    host,
+    result.catch(() => {}),
+  );
+  return result;
+}
+
+/** Reads Retry-After (seconds or HTTP date) into a millisecond delay, if present. */
+function parseRetryAfterMs(res: Response): number | null {
+  const header = res.headers.get("retry-after");
+  if (!header) return null;
+  const seconds = Number(header);
+  if (!Number.isNaN(seconds)) return seconds * 1000;
+  const dateMs = Date.parse(header);
+  return Number.isNaN(dateMs) ? null : dateMs - Date.now();
+}
+
 /** Increased timeout to 45s to avoid AbortErrors under load */
 export async function safeFetch(
   url: string,
@@ -243,18 +275,33 @@ export async function safeFetch(
   extraHeaders?: Record<string, string>,
 ): Promise<Response | null> {
   trackDomainRequest(url);
+
+  let host: string;
   try {
-    return await fetch(url, {
+    host = new URL(url).host;
+  } catch {
+    host = "unknown";
+  }
+
+  const doFetch = () =>
+    fetch(url, {
       headers: {
         "User-Agent":
           "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
         ...extraHeaders,
       },
       signal: AbortSignal.timeout(timeout),
-    });
-  } catch {
-    return null;
+    }).catch(() => null);
+
+  for (let attempt = 0; attempt <= MAX_429_RETRIES; attempt++) {
+    const res = await queueByHost(host, doFetch);
+    if (!res) return null;
+    if (res.status !== 429 || attempt === MAX_429_RETRIES) return res;
+
+    const backoffMs = parseRetryAfterMs(res) ?? 1000 * 2 ** (attempt + 1);
+    await new Promise((r) => setTimeout(r, Math.min(Math.max(backoffMs, 500), 15_000)));
   }
+  return null; // unreachable — loop always returns
 }
 
 /** For local jobs: extract a specific Egyptian city from the raw location string. */
@@ -751,8 +798,8 @@ export async function fetchSmartRecruiters(c: ATSConfig, mode: JobMode): Promise
   try {
     const { content } = (await res.json()) as { content: SRJob[] };
     const rawCount = content.length;
-    const detailedJobs = await Promise.all(
-      content.map(async (r) => {
+    const detailedJobs = await pLimit(
+      content.map((r) => async () => {
         const detailRes = await safeFetch(r.ref);
         if (!detailRes || !detailRes.ok) return null;
         try {
@@ -769,6 +816,7 @@ export async function fetchSmartRecruiters(c: ATSConfig, mode: JobMode): Promise
           return null;
         }
       }),
+      5,
     );
     const processed = processJobs(
       detailedJobs.filter((j): j is ATSRawInput => j !== null),


### PR DESCRIPTION
fix: rate-limit ATS fetchers hitting shared-host APIs (issue #52)

Root cause: Greenhouse, Lever, Ashby, and SmartRecruiters each serve every
company from one shared host (boards-api.greenhouse.io, api.lever.co,
api.ashbyhq.com, api.smartrecruiters.com). The runner's concurrency limit
(8) has no host awareness, so up to 8 companies on the same ATS could fire
simultaneously with zero stagger and zero retry — the exact pattern that
trips a shared API's rate limiter. Workable was the only fetcher with any
protection against this (host queue + cooldown), which is why everything
else in the flagged list (bayutdubizzle, jupiterone, isentia, etc.) kept
getting 429'd.

- safeFetch() — the shared chokepoint for every non-Workable fetcher — now
  queues requests per host with a randomized 200-600ms stagger, and retries
  up to twice on 429, honoring Retry-After (falls back to exponential
  backoff) instead of giving up for the rest of the run
- fetchSmartRecruiters' detail-page loop used a raw Promise.all with no
  concurrency cap at all (unlike BambooHR/Workable, which already use
  pLimit) — switched to pLimit(5), same pattern as the others

No DB schema changes. Cross-run cooldown persistence (like Workable's
workable_blocked column) would need a migration and is a reasonable
follow-up if in-run throttling alone doesn't fully clear the 429s, but
this addresses the actual observed cause without one.

- retries on 429 and returns the eventual success
- gives up after MAX_429_RETRIES instead of hanging forever
- concurrent requests to the same host are staggered, not fired at once
  (the exact burst pattern that caused issue #52)
- different hosts don't queue behind each other