### PR TITLE
fix: propagate fetcher errors instead of hardcoding null (issue #52 follow-up)

### DIFF
--- a/src/lib/ats-bridge.ts
+++ b/src/lib/ats-bridge.ts
@@ -62,52 +62,62 @@ export async function fetchCompany(row: ATSCompanyRow, mode: JobMode): Promise<F
 
   try {
     let rawJobs: Job[] = [];
+    let fetchError: string | null = null;
 
     // All fetchers compute visa_sponsorship from content internally.
     switch (row.ats) {
       case "greenhouse": {
         const result = await fetchGreenhouse(config, mode);
         rawJobs = result.jobs;
+        if (result.error) fetchError = result.error;
         break;
       }
       case "lever": {
         const result = await fetchLever(config, mode);
         rawJobs = result.jobs;
+        if (result.error) fetchError = result.error;
         break;
       }
       case "ashby": {
         const result = await fetchAshby(config, mode);
         rawJobs = result.jobs;
+        if (result.error) fetchError = result.error;
         break;
       }
       case "workable": {
         const result = await fetchWorkable(config, mode);
         rawJobs = result.jobs;
+        if (result.error) fetchError = result.error;
         break;
       }
       case "teamtailor": {
         const result = await fetchTeamtailor(config, mode);
         rawJobs = result.jobs;
+        if (result.error) fetchError = result.error;
         break;
       }
       case "breezy": {
         const result = await fetchBreezy(config, mode);
         rawJobs = result.jobs;
+        if (result.error) fetchError = result.error;
         break;
       }
       case "smartrecruiters": {
         const result = await fetchSmartRecruiters(config, mode);
         rawJobs = result.jobs;
+        if (result.error) fetchError = result.error;
         break;
       }
       case "bamboohr": {
         const result = await fetchBambooHR(config, mode);
         rawJobs = result.jobs;
+        if (result.error) fetchError = result.error;
         break;
       }
       case "jazzhr": {
         const result = await fetchJazzHR(config, mode);
         rawJobs = result.jobs;
+        if (result.error) fetchError = result.error;
         break;
       }
       default:
@@ -143,7 +153,7 @@ export async function fetchCompany(row: ATSCompanyRow, mode: JobMode): Promise<F
       };
     });
 
-    return { company: row.name, mode, jobs, error: null };
+    return { company: row.name, mode, jobs, error: fetchError };
   } catch (err) {
     const error = err instanceof Error ? err.message : String(err);
     return { company: row.name, mode, jobs: [], error };


### PR DESCRIPTION
fetchCompany() wraps all nine ATS fetchers in a try/catch, but none of them throw on failure — each one catches its own errors internally and returns { jobs: [], error: 'HTTP 429', ... } as a normal value. The switch statement only ever pulled result.jobs, discarded result.error, and the final return hardcoded error: null unconditionally. This means cron_logs_v2.errors has never been able to contain '429' regardless of how many actually happened — a 429'd company and a company with zero open roles were indistinguishable in the log.

Fixed by propagating result.error through to FetchResult.error. Keyed on  being set, not  — ok is inconsistently
set across the nine fetchers' return paths (38/43), so using it as the failure signal was flagging legitimate successes as failures. Caught by the existing ats-bridge test suite, which is the whole reason it exists.