### PR TITLE
fix(ats): complete safeFetchJson rollout to remaining 7 fetchers; extract ATS_TYPES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,27 @@ All notable changes to this project are documented in this file.
   `Parse Error: SyntaxError` instead of the real cause (confirmed repro:
   Artefactual Systems Inc. on Breezy). Added `safeFetchJson()` (`http.ts`)
   checking status, then `content-type`, then parsing; migrated `breezy.ts`.
-  The remaining 7 fetchers (ashby, bamboohr, greenhouse, lever,
-  smart-recruiters, teamtailor, and `workable.ts`'s list-call) are still on
-  the old pattern — a live instance of the same bug class was caught on
-  Teamtailor (Yodo1) during validation of this fix, see the doc above for
-  the updated rollout order.
+  Rollout now complete: `teamtailor.ts`, `ashby.ts`, `greenhouse.ts`,
+  `lever.ts`, `smart-recruiters.ts`, `bamboohr.ts` migrated in full, and
+  `workable.ts`'s list-call (its per-job detail-fetch path is untouched on
+  purpose — see below). `http.ts`'s `safeFetchJson` was split into
+  `parseJsonBody` (takes a `Response | null` directly) + a thin
+  `safeFetch`-calling wrapper, so `workable.ts` — which queues/retries its
+  own fetches — can reuse the parsing half without duplicating it.
+  `teamtailor.ts` additionally gained an explicit `Array.isArray` guard on
+  the parsed body's `data` field: `safeFetchJson` only confirms the body
+  parsed as JSON, not that it matches the expected shape, and Yodo1's board
+  returned valid JSON with no `data` array, crashing the old `data.length`
+  on `undefined` — a live instance of this caught during validation, see
+  `docs/solutions/bugs/issue-52-429-404-followup-part4.md`. No equivalent
+  guard was added to `greenhouse.ts`, `lever.ts`, or `smart-recruiters.ts`,
+  which have the same latent shape-trust issue with no fallback — flagged
+  in-code, not fixed, with no live evidence of it firing for those three.
+  `smart-recruiters.ts`'s per-job detail-fetch loop (left on the old
+  pattern, same carve-out as `workable.ts`'s) has a separate pre-existing
+  issue: a bad detail response returns `null` and the job is silently
+  dropped rather than falling back to a list-level description — also
+  flagged, not fixed, out of scope for this rollout.
 - JazzHR removed entirely (fetcher, `ATSType` union member, submit-form
   option, and all references) — confirmed dead. Two companies (TED,
   Roadpass Digital) were being dispatched twice, once under their real ATS
@@ -56,6 +72,13 @@ text[]` column) and the `cron:log` console summary.
   the detail-page fanout checks the block before each request instead of
   only once before the list call. See
   `docs/solutions/bugs/issue-52-504-recurrence-part4.md`.
+
+- `src/app/submit/page.tsx`: `ATS_TYPES` (the ATS-type `<select>`'s options —
+  value, label, slug-hint) was defined inline in the component, a
+  pre-existing violation of this repo's react-component-architecture
+  convention (constants always move out of component files). Extracted to
+  `src/lib/constants.ts`, next to the existing `VALID_ATS`. No behavior
+  change. See `docs/solutions/bugs/issue-52-429-404-followup-part4.md`.
 
 - `runner.ts`: zero logging existed for any step between the upsert phase and
   the end of the function — `app_config` update, `flushWorkable429sToDB`,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -352,6 +352,25 @@ returning a normalized `Job[]`. Shared concerns handled in this file:
 - **HTML stripping** (`stripHtml`) and a bounded **`safeFetch`** (45s per-attempt
   timeout, 90s total-wall-clock ceiling across every attempt/backoff combined — see
   below) for resilience against slow/unresponsive ATS endpoints.
+- **JSON-safety** (`src/lib/sources/ats/http.ts`'s `safeFetchJson` / `parseJsonBody`):
+  a 200-status WAF/bot-challenge page satisfies `res.ok` but crashes a bare
+  `res.json()` call, surfacing as a misleading generic parse error. `parseJsonBody`
+  checks status, then `content-type`, then parses, returning one consistent result
+  type instead of each fetcher repeating (and drifting on) the same three failure
+  modes; `safeFetchJson` wraps `safeFetch` + `parseJsonBody` for the common case,
+  and `workable.ts` calls `parseJsonBody` directly on the `Response` its own queued
+  fetch already produced. All 8 fetchers use one or the other for their list-call.
+  Two fetchers' per-job detail-fetch fan-out (`workable.ts`, `bamboohr.ts`) are left
+  on their own inline `res.ok`/`try-catch` handling by design — a bad detail
+  response there already degrades gracefully (falls back to the list description)
+  rather than crashing, so it isn't the failure mode this pattern targets.
+  `teamtailor.ts` additionally guards the parsed body's shape explicitly
+  (`Array.isArray` on the expected `data` field): JSON-safety alone doesn't catch a
+  200 response whose body is valid JSON but missing the expected field, which is
+  what actually crashed on a live board (Yodo1) — see
+  `docs/solutions/bugs/issue-52-429-404-followup-part3.md`. The same shape-trust
+  gap exists in `greenhouse.ts`, `lever.ts`, and `smart-recruiters.ts` with no live
+  evidence of it firing there; noted in each file rather than speculatively fixed.
 - **Concurrency limiting** (`pLimit`) for fan-out within a single ATS call, separate from
   the cross-company limiter in `runner.ts`.
 - **Per-host lane pools** (`src/lib/sources/ats/http.ts`'s `queueByHost`,

--- a/docs/solutions/bugs/issue-52-429-404-followup-part3.md
+++ b/docs/solutions/bugs/issue-52-429-404-followup-part3.md
@@ -214,18 +214,15 @@ naming so they don't recur:
 
 ## Remaining / open work — priority order for next session
 
-1. **`safeFetchJson` rollout, teamtailor first.** Yodo1's live TypeError
-   above is concrete proof this isn't hypothetical for this fetcher.
-   Migrate `teamtailor.ts`, verify against Yodo1's real board, then do
-   `workable.ts`'s list-call (note: only the list call — the detail-fetch
-   path already has its own graceful-fallback handling from `362bdd8` and
-   doesn't need this), then the remaining five (ashby, bamboohr, greenhouse,
-   lever, smart-recruiters) one at a time against a live company each, per
-   the original plan. Don't blanket find/replace.
-2. **`ATS_TYPES` array in `submit/page.tsx`** — pre-existing
-   react-component-architecture violation (inline constants array), flagged
-   but correctly not bundled into the JazzHR removal PR. ~10 minute fix:
-   extract to `constants/ats.ts` or equivalent.
+1. ~~**`safeFetchJson` rollout, teamtailor first.**~~ **Done** — see
+   `issue-52-429-404-followup-part4.md`. All 7 remaining fetchers migrated;
+   `teamtailor.ts` additionally got an explicit shape guard (Yodo1's actual
+   failure was valid JSON with no `data` array, which `safeFetchJson` alone
+   doesn't catch). Live per-company verification against `pnpm cron:log`
+   still needs to happen in a real environment — not done from this
+   session's sandbox, see part 4 for why.
+2. ~~**`ATS_TYPES` array in `submit/page.tsx`**~~ **Done** — extracted to
+   `src/lib/constants.ts`, see `issue-52-429-404-followup-part4.md`.
 3. **Admin dashboard cron-summary card** — doesn't display `errors` or
    `warnings` today (confirmed: `select("run_at, total_fetched, duration_ms,
 trigger")` in `src/app/(protected)/admin/page.tsx`). Explicitly deferred
@@ -240,6 +237,14 @@ trigger")` in `src/app/(protected)/admin/page.tsx`). Explicitly deferred
 7. **Commit hygiene** — see the two process gaps above. No code change
    needed, just a habit: verify file lists and counts against `git show
 --stat` before writing the message that describes them.
+8. **New from part 4**: no shape guard was added to `greenhouse.ts`,
+   `lever.ts`, or `smart-recruiters.ts`, which have the same latent
+   shape-trust gap teamtailor had — no live evidence of it firing for these
+   three, so flagged in-code rather than fixed. Also new:
+   `smart-recruiters.ts`'s per-job detail-fetch loop silently drops a job
+   entirely on a bad detail response (returns `null`, filtered out) rather
+   than falling back to a list-level description like `workable.ts`/
+   `bamboohr.ts` do — pre-existing, real, out of scope for part 4.
 
 ## Files touched or referenced this session
 

--- a/docs/solutions/bugs/issue-52-429-404-followup-part4.md
+++ b/docs/solutions/bugs/issue-52-429-404-followup-part4.md
@@ -1,0 +1,165 @@
+---
+date: 2026-07-07
+category: bugs
+tags:
+  [
+    ats,
+    safefetchjson,
+    teamtailor,
+    workable,
+    ashby,
+    greenhouse,
+    lever,
+    smartrecruiters,
+    bamboohr,
+    submit-form,
+  ]
+files:
+  [
+    src/lib/sources/ats/http.ts,
+    src/lib/sources/ats/teamtailor.ts,
+    src/lib/sources/ats/ashby.ts,
+    src/lib/sources/ats/greenhouse.ts,
+    src/lib/sources/ats/lever.ts,
+    src/lib/sources/ats/smart-recruiters.ts,
+    src/lib/sources/ats/bamboohr.ts,
+    src/lib/sources/ats/workable.ts,
+    src/lib/constants.ts,
+    src/app/submit/page.tsx,
+    src/lib/__tests__/teamtailor-shape-guard.test.ts,
+    src/lib/__tests__/ats-utils-tracking.test.ts,
+    src/lib/__tests__/workable-detail-warnings.test.ts,
+    src/lib/__tests__/workable-rate-limit.test.ts,
+  ]
+---
+
+# Issue #52, 429/404 follow-up — part 4: closing priorities 1 and 2
+
+Closes items 1 and 2 from part 3's remaining-work list: the rest of the
+`safeFetchJson` rollout, and the `ATS_TYPES` extraction.
+
+## Priority 1 — `safeFetchJson` rollout, remaining 7 fetchers
+
+### `http.ts`: split `safeFetchJson` into `parseJsonBody` + a thin wrapper
+
+`workable.ts` doesn't call `safeFetch` — it has its own queued/retried
+`fetchWorkableUrl`, so it already has a `Response | null` by the time it
+needs JSON-safety. Duplicating `safeFetchJson`'s body/content-type logic
+inside `workable.ts` would drift from `http.ts`'s copy over time. Split
+instead: `parseJsonBody(res: Response | null)` holds all the logic
+(null check, status check, content-type check, parse), `safeFetchJson`
+is now just `safeFetch` + `parseJsonBody`. No behavior change for any
+existing caller — same three failure strings, same happy path.
+
+### `teamtailor.ts` — migrated, plus a shape guard
+
+Migrated to `safeFetchJson`. Additionally added an explicit
+`Array.isArray(result.data.data)` guard before touching `.length`/`.map`.
+
+This part matters: `safeFetchJson` only confirms the body parsed as JSON —
+it says nothing about whether the parsed value has the shape the caller
+expects. Yodo1's board (part 3) returned HTTP 200, valid JSON, content-type
+`application/json`, and no `data` field. A blind `safeFetchJson` swap
+would have "fixed" this by moving the exact same `TypeError: Cannot read
+properties of undefined (reading 'length')` from an inner try/catch
+(→ `Parse Error: TypeError...`) to `ats-bridge.ts`'s outer catch (→ same
+message, no `Parse Error:` prefix) — a different string, not a different
+outcome. The guard makes it an actual, named, non-crashing result:
+`Unexpected response shape: missing \`data\` array`.
+
+New test: `teamtailor-shape-guard.test.ts` — one case reproducing Yodo1's
+exact response (valid JSON, no `data` field) asserting the clean error, one
+happy-path case with a proper `data` array. This is the only fetcher change
+in this rollout with a dedicated new test, because it's the only one with
+new _logic_ — the other six are a mechanical pattern swap.
+
+### `ashby.ts`, `greenhouse.ts`, `lever.ts`, `smart-recruiters.ts`, `bamboohr.ts` — migrated, list-call only where a detail-fetch exists
+
+Straight `safeFetchJson` swap, each fetcher's existing null-safety
+preserved exactly (`ashby.ts`'s `data.jobs || data.jobPostings || []`,
+`bamboohr.ts`'s `data.result ?? []`).
+
+**No shape guard added to `greenhouse.ts`, `lever.ts`, or
+`smart-recruiters.ts`**, even though all three have the identical
+no-fallback pattern teamtailor had (`const { jobs } = ... as {jobs: T[]}`,
+`(await res.json()) as T[]` with no shape check, `const { content } = ...`).
+This is a deliberate scope decision, not an oversight: teamtailor's guard
+exists because Yodo1 proved it live. No board has shown this failure for
+these three. Adding a guard on spec, with nothing to verify it against, is
+unfalsifiable — flagged in each file's source as a comment instead, per
+this project's own established pattern (see part 3's "Process gaps"
+section) of flagging real-but-unevidenced issues rather than bundling
+speculative fixes into an unrelated change.
+
+**`bamboohr.ts`'s and `smart-recruiters.ts`'s per-job detail-fetch loops
+are untouched**, same carve-out part 3 already gave `workable.ts`'s detail
+path: `bamboohr.ts`'s already falls back to an empty description on any
+bad response (own inline try/catch); `smart-recruiters.ts`'s already
+returns `null` on any bad response, filtering the job out entirely. Neither
+crashes today, so neither is the failure class this rollout targets.
+
+One new thing worth naming, though: `smart-recruiters.ts`'s "silently drop
+the job" behavior is a _worse_ degradation than `bamboohr.ts`'s or
+`workable.ts`'s "fall back to a shorter description" — a job just vanishes
+from results with no visibility, similar in spirit to the dead-link problem
+`362bdd8` fixed for `workable.ts` specifically. Real, pre-existing, not
+touched here — added to part 3's remaining-work list (item 8) rather than
+silently left findable only in a code comment.
+
+### `workable.ts` — list-call only
+
+List-call swapped to call `parseJsonBody` directly on `fetchWorkableUrl`'s
+`Response`. Detail-fetch path (`resolveJobDescription`) is completely
+unchanged — part 3 already carved this out, and re-confirmed here: it
+already degrades gracefully, so migrating it doesn't fix anything, and
+`parseJsonBody`'s stricter content-type check would only make an existing
+graceful-fallback outcome arrive by a longer path.
+
+Three existing tests' mocks (`workable-detail-warnings.test.ts`,
+`workable-rate-limit.test.ts`) had list-response mocks with no
+`content-type` header and (in one file) only a `.json()` method, not
+`.text()` — both are things the old `res.ok` + `res.json()` pattern never
+cared about, but `parseJsonBody` does. Updated the shared
+`mockListResponse` helper in both files to set
+`content-type: application/json` and provide `.text()` instead of `.json()`
+for the list mock — this is the mock catching up to what a real successful
+JSON response looks like, not a weakened test. Same fix applied to
+`ats-utils-tracking.test.ts`'s teamtailor mock, which had the same gap.
+
+### What this rollout does _not_ cover
+
+Live per-company verification (`pnpm cron:log` against each ATS's real
+board) — the thing part 3's validation run actually did for the three
+commits it covered. Not possible from this session's sandbox: no network
+route to any of these ATS hosts, no Supabase credentials, and this repo
+has no dry-run mode — a real run writes production data and emails real
+users (part 3's "known limitation" note). Verified instead with
+`tsc --noEmit`, `eslint`, and the full `vitest` suite (all green, 379/379,
+2 new), plus the dedicated shape-guard test proving Yodo1's specific
+failure is now handled. Live verification per company is still open —
+someone with real access needs to run it.
+
+## Priority 2 — `ATS_TYPES` extraction
+
+Moved from an inline array in `src/app/submit/page.tsx` into
+`src/lib/constants.ts`, next to the existing `VALID_ATS`. No new file —
+this repo already has a shared constants file with the same domain's other
+constant (`VALID_ATS`), so the extraction target already existed. Pure
+relocation, zero behavior change; `tsc`/`eslint`/full suite all confirm
+this independently of the commit message.
+
+## Verification summary
+
+- `tsc --noEmit`: clean.
+- `eslint` on every touched file: clean.
+- `vitest run src/lib/__tests__`: 38 files, 379 tests, all passing
+  (377 pre-existing + 2 new in `teamtailor-shape-guard.test.ts`).
+- Full diff: 13 files modified, 1 new test file. No `.ts`/`.tsx` file
+  outside `src/lib/sources/ats/`, `src/lib/constants.ts`,
+  `src/app/submit/page.tsx`, and test files touched.
+
+## Remaining / open work, updated
+
+See part 3's remaining-work list, items 3–7 (unchanged, still open) plus
+new item 8 (shape-guard gap in 3 fetchers + smart-recruiters silent-drop,
+both flagged not fixed — see above).

--- a/src/app/submit/page.tsx
+++ b/src/app/submit/page.tsx
@@ -5,33 +5,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-
-const ATS_TYPES = [
-  {
-    value: "greenhouse",
-    label: "Greenhouse",
-    slug_hint: 'Your Greenhouse board token (e.g. "acmecorp")',
-  },
-  { value: "lever", label: "Lever", slug_hint: 'Your Lever company slug (e.g. "acme")' },
-  { value: "ashby", label: "Ashby", slug_hint: "Your Ashby organisation slug" },
-  {
-    value: "workable",
-    label: "Workable",
-    slug_hint: 'Your Workable subdomain (e.g. "acme" from acme.workable.com)',
-  },
-  { value: "teamtailor", label: "Teamtailor", slug_hint: "Your Teamtailor company slug" },
-  { value: "breezy", label: "Breezy HR", slug_hint: "Your Breezy company slug" },
-  {
-    value: "smartrecruiters",
-    label: "SmartRecruiters",
-    slug_hint: "Your SmartRecruiters company ID",
-  },
-  {
-    value: "bamboohr",
-    label: "BambooHR",
-    slug_hint: 'Your BambooHR subdomain (e.g. "acme" from acme.bamboohr.com)',
-  },
-];
+import { ATS_TYPES } from "@/lib/constants";
 
 const LABEL_CLASS = "mb-1.5 block text-[13px] font-medium text-[#94a3b8]";
 const INPUT_CLASS =

--- a/src/lib/__tests__/ats-utils-tracking.test.ts
+++ b/src/lib/__tests__/ats-utils-tracking.test.ts
@@ -39,7 +39,12 @@ describe("Teamtailor/Breezy domain_counts tracking", () => {
   it("tracks the teamtailor host via safeFetch instead of bypassing it", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({ data: [] }) }),
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: new Headers({ "content-type": "application/json" }),
+        text: async () => JSON.stringify({ data: [] }),
+      }),
     );
 
     const { fetchTeamtailor, flushDomainCountsToDB } = await import("../sources/ats-utils");

--- a/src/lib/__tests__/teamtailor-shape-guard.test.ts
+++ b/src/lib/__tests__/teamtailor-shape-guard.test.ts
@@ -1,0 +1,75 @@
+// src/lib/__tests__/teamtailor-shape-guard.test.ts
+//
+// Yodo1's Teamtailor board (issue-52-429-404-followup-part3.md) returned
+// HTTP 200, content-type application/json, and a body that parsed fine but
+// had no `data` array — the old code did `const { data } = await res.json()`
+// then `data.length`, which crashed with `TypeError: Cannot read properties
+// of undefined (reading 'length')`. safeFetchJson's content-type/parse check
+// doesn't catch this on its own, since the body IS valid JSON — this guards
+// the shape explicitly. This test fails if that guard is ever removed or
+// loosened.
+import { describe, it, expect, vi, afterEach } from "vitest";
+import type { ATSConfig } from "@/types";
+
+const baseCompany: ATSConfig = {
+  name: "Yodo1",
+  slug: "yodo1",
+  country: "US",
+  countryFlag: "🇺🇸",
+  ats: "teamtailor",
+};
+
+function mockJsonResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    headers: new Headers({ "content-type": "application/json" }),
+    text: async () => JSON.stringify(body),
+  };
+}
+
+describe("fetchTeamtailor — response-shape guard", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns a clean error instead of crashing when valid JSON has no `data` array", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(mockJsonResponse({ meta: { ok: true } })));
+
+    const { fetchTeamtailor } = await import("../sources/ats/teamtailor");
+    const result = await fetchTeamtailor(baseCompany, "global");
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("Unexpected response shape: missing `data` array");
+    expect(result.jobs).toEqual([]);
+  });
+
+  it("still processes jobs normally when `data` is a proper array", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        mockJsonResponse({
+          data: [
+            {
+              id: "1",
+              attributes: {
+                title: "Engineer",
+                "location-name": "Remote",
+                "external-url": "https://example.com/jobs/1",
+                "published-at": "2026-01-01",
+                "body-html": "<p>desc</p>",
+              },
+            },
+          ],
+        }),
+      ),
+    );
+
+    const { fetchTeamtailor } = await import("../sources/ats/teamtailor");
+    const result = await fetchTeamtailor(baseCompany, "global");
+
+    expect(result.ok).toBe(true);
+    expect(result.rawCount).toBe(1);
+    expect(result.jobs).toHaveLength(1);
+  });
+});

--- a/src/lib/__tests__/workable-detail-warnings.test.ts
+++ b/src/lib/__tests__/workable-detail-warnings.test.ts
@@ -17,7 +17,12 @@ const baseCompany: ATSConfig = {
 };
 
 function mockListResponse(jobs: unknown[]) {
-  return { status: 200, ok: true, headers: new Headers(), json: async () => ({ jobs }) };
+  return {
+    status: 200,
+    ok: true,
+    headers: new Headers({ "content-type": "application/json" }),
+    text: async () => JSON.stringify({ jobs }),
+  };
 }
 
 const ADVANCE_MS = 40_000;

--- a/src/lib/__tests__/workable-rate-limit.test.ts
+++ b/src/lib/__tests__/workable-rate-limit.test.ts
@@ -20,8 +20,8 @@ function mockListResponse(jobs: unknown[] = []) {
   return {
     status: 200,
     ok: true,
-    headers: new Headers(),
-    json: async () => ({ jobs }),
+    headers: new Headers({ "content-type": "application/json" }),
+    text: async () => JSON.stringify({ jobs }),
   };
 }
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -15,6 +15,39 @@ export const VALID_ATS: ATSType[] = [
   "bamboohr",
 ];
 
+/**
+ * Options for the ATS-type <select> on the public submit form: value, display
+ * label, and the slug-format hint shown once that ATS is picked. Extracted
+ * from src/app/submit/page.tsx (react-component-architecture: constants
+ * always move out of component files, regardless of reuse count).
+ */
+export const ATS_TYPES: { value: ATSType; label: string; slug_hint: string }[] = [
+  {
+    value: "greenhouse",
+    label: "Greenhouse",
+    slug_hint: 'Your Greenhouse board token (e.g. "acmecorp")',
+  },
+  { value: "lever", label: "Lever", slug_hint: 'Your Lever company slug (e.g. "acme")' },
+  { value: "ashby", label: "Ashby", slug_hint: "Your Ashby organisation slug" },
+  {
+    value: "workable",
+    label: "Workable",
+    slug_hint: 'Your Workable subdomain (e.g. "acme" from acme.workable.com)',
+  },
+  { value: "teamtailor", label: "Teamtailor", slug_hint: "Your Teamtailor company slug" },
+  { value: "breezy", label: "Breezy HR", slug_hint: "Your Breezy company slug" },
+  {
+    value: "smartrecruiters",
+    label: "SmartRecruiters",
+    slug_hint: "Your SmartRecruiters company ID",
+  },
+  {
+    value: "bamboohr",
+    label: "BambooHR",
+    slug_hint: 'Your BambooHR subdomain (e.g. "acme" from acme.bamboohr.com)',
+  },
+];
+
 export const VALID_STATUSES: TrackerStatus[] = [
   "applied",
   "interviewing",

--- a/src/lib/sources/ats/ashby.ts
+++ b/src/lib/sources/ats/ashby.ts
@@ -2,54 +2,36 @@
 // Split out of ats-utils.ts (see AUDIT_STATUS.md row #2) — no behavior change.
 import type { ATSConfig, FetcherResult, AshbyJob } from "@/types";
 import type { JobMode } from "@/lib/types";
-import { safeFetch } from "./http";
+import { safeFetchJson } from "./http";
 import { processJobs, stripHtml } from "./job-processing";
 
 export async function fetchAshby(c: ATSConfig, mode: JobMode): Promise<FetcherResult> {
   const t0 = Date.now();
   const url = `https://api.ashbyhq.com/posting-api/job-board/${c.slug}`;
-  const res = await safeFetch(url);
+  const result = await safeFetchJson<{ jobs?: AshbyJob[]; jobPostings?: AshbyJob[] }>(url);
 
-  if (!res)
+  if (!result.ok)
     return {
       jobs: [],
       rawCount: 0,
-      error: "Network/Timeout",
+      error: result.error,
       durationMs: Date.now() - t0,
       ok: false,
     };
-  if (!res.ok)
-    return {
-      jobs: [],
-      rawCount: 0,
-      error: `HTTP ${res.status}`,
-      durationMs: Date.now() - t0,
-      ok: false,
-    };
-  try {
-    const data = (await res.json()) as { jobs?: AshbyJob[]; jobPostings?: AshbyJob[] };
-    const jobs = data.jobs || data.jobPostings || [];
-    const rawCount = jobs.length;
-    const processed = processJobs(
-      jobs.map((r) => ({
-        id: `${mode}_ashby_${c.slug}_${r.id}`,
-        title: r.title,
-        location: r.locationName ?? c.city ?? c.country,
-        url: r.jobUrl,
-        postedAt: r.publishedAt,
-        description: stripHtml(r.descriptionHtml || ""),
-      })),
-      c,
-      mode,
-    );
-    return { jobs: processed, rawCount, durationMs: Date.now() - t0, ok: true };
-  } catch (e) {
-    return {
-      jobs: [],
-      rawCount: 0,
-      error: `Parse Error: ${e}`,
-      durationMs: Date.now() - t0,
-      ok: false,
-    };
-  }
+
+  const jobs = result.data.jobs || result.data.jobPostings || [];
+  const rawCount = jobs.length;
+  const processed = processJobs(
+    jobs.map((r) => ({
+      id: `${mode}_ashby_${c.slug}_${r.id}`,
+      title: r.title,
+      location: r.locationName ?? c.city ?? c.country,
+      url: r.jobUrl,
+      postedAt: r.publishedAt,
+      description: stripHtml(r.descriptionHtml || ""),
+    })),
+    c,
+    mode,
+  );
+  return { jobs: processed, rawCount, durationMs: Date.now() - t0, ok: true };
 }

--- a/src/lib/sources/ats/bamboohr.ts
+++ b/src/lib/sources/ats/bamboohr.ts
@@ -2,68 +2,55 @@
 // Split out of ats-utils.ts (see AUDIT_STATUS.md row #2) — no behavior change.
 import type { ATSConfig, ATSRawInput, FetcherResult, BambooJob, BambooDetail } from "@/types";
 import type { JobMode } from "@/lib/types";
-import { safeFetch } from "./http";
+import { safeFetch, safeFetchJson } from "./http";
 import { processJobs, stripHtml, pLimit } from "./job-processing";
 
 export async function fetchBambooHR(c: ATSConfig, mode: JobMode): Promise<FetcherResult> {
   const t0 = Date.now();
   const url = `https://${c.slug}.bamboohr.com/careers/list`;
-  const res = await safeFetch(url);
+  const result = await safeFetchJson<{ result?: BambooJob[] }>(url);
 
-  if (!res)
+  if (!result.ok)
     return {
       jobs: [],
       rawCount: 0,
-      error: "Network/Timeout",
+      error: result.error,
       durationMs: Date.now() - t0,
       ok: false,
     };
-  if (!res.ok)
-    return {
-      jobs: [],
-      rawCount: 0,
-      error: `HTTP ${res.status}`,
-      durationMs: Date.now() - t0,
-      ok: false,
-    };
-  try {
-    const data = (await res.json()) as { result?: BambooJob[] };
-    const jobs = data.result ?? [];
-    const rawCount = jobs.length;
-    // BambooHR's list endpoint never includes a description.
-    // Fetch each job's detail page for the real description,
-    // mirroring fetchWorkable's detail-fetch pattern.
-    const withDesc = await pLimit(
-      jobs.map((r) => async () => {
-        let description = "";
-        const detailUrl = `https://${c.slug}.bamboohr.com/careers/${r.id}/detail`;
-        const dr = await safeFetch(detailUrl);
-        if (dr && dr.ok) {
-          try {
-            const detail = (await dr.json()) as BambooDetail;
-            description = stripHtml(detail.result?.jobOpening?.description ?? "");
-          } catch {}
-        }
-        return {
-          id: `${mode}_bamboohr_${c.slug}_${r.id}`,
-          title: r.jobOpeningName,
-          location: r.city ? `${r.city}, ${r.country}` : (c.city ?? c.country),
-          url: `https://${c.slug}.bamboohr.com/careers/${r.id}`,
-          postedAt: r.datePosted,
-          description,
-        };
-      }),
-      5,
-    );
-    const processed = processJobs(withDesc.filter(Boolean) as ATSRawInput[], c, mode);
-    return { jobs: processed, rawCount, durationMs: Date.now() - t0, ok: true };
-  } catch (e) {
-    return {
-      jobs: [],
-      rawCount: 0,
-      error: `Parse Error: ${e}`,
-      durationMs: Date.now() - t0,
-      ok: false,
-    };
-  }
+
+  const jobs = result.data.result ?? [];
+  const rawCount = jobs.length;
+  // BambooHR's list endpoint never includes a description.
+  // Fetch each job's detail page for the real description,
+  // mirroring fetchWorkable's detail-fetch pattern.
+  //
+  // Per-job detail fetch is left on the old safeFetch + res.ok + try/catch
+  // pattern on purpose — same carve-out as workable.ts's detail path. A bad
+  // detail response here already degrades gracefully (empty description,
+  // job still kept), so it isn't the crash class this migration targets.
+  const withDesc = await pLimit(
+    jobs.map((r) => async () => {
+      let description = "";
+      const detailUrl = `https://${c.slug}.bamboohr.com/careers/${r.id}/detail`;
+      const dr = await safeFetch(detailUrl);
+      if (dr && dr.ok) {
+        try {
+          const detail = (await dr.json()) as BambooDetail;
+          description = stripHtml(detail.result?.jobOpening?.description ?? "");
+        } catch {}
+      }
+      return {
+        id: `${mode}_bamboohr_${c.slug}_${r.id}`,
+        title: r.jobOpeningName,
+        location: r.city ? `${r.city}, ${r.country}` : (c.city ?? c.country),
+        url: `https://${c.slug}.bamboohr.com/careers/${r.id}`,
+        postedAt: r.datePosted,
+        description,
+      };
+    }),
+    5,
+  );
+  const processed = processJobs(withDesc.filter(Boolean) as ATSRawInput[], c, mode);
+  return { jobs: processed, rawCount, durationMs: Date.now() - t0, ok: true };
 }

--- a/src/lib/sources/ats/greenhouse.ts
+++ b/src/lib/sources/ats/greenhouse.ts
@@ -2,61 +2,49 @@
 // Split out of ats-utils.ts (see AUDIT_STATUS.md row #2) — no behavior change.
 import type { ATSConfig, FetcherResult, GreenhouseJob } from "@/types";
 import type { JobMode } from "@/lib/types";
-import { safeFetch } from "./http";
+import { safeFetchJson } from "./http";
 import { processJobs, stripHtml } from "./job-processing";
 
 export async function fetchGreenhouse(c: ATSConfig, mode: JobMode): Promise<FetcherResult> {
   const t0 = Date.now();
   const url = `https://boards-api.greenhouse.io/v1/boards/${c.slug}/jobs?content=true`;
-  const res = await safeFetch(url);
+  const result = await safeFetchJson<{ jobs: GreenhouseJob[] }>(url);
 
-  if (!res)
+  if (!result.ok)
     return {
       jobs: [],
       rawCount: 0,
-      error: "Network/Timeout",
+      error: result.error,
       durationMs: Date.now() - t0,
       ok: false,
     };
-  if (!res.ok)
-    return {
-      jobs: [],
-      rawCount: 0,
-      error: `HTTP ${res.status}`,
-      durationMs: Date.now() - t0,
-      ok: false,
-    };
-  try {
-    const { jobs } = (await res.json()) as { jobs: GreenhouseJob[] };
-    const rawCount = jobs.length;
-    const processed = processJobs(
-      jobs.map((r) => {
-        const officeNames = (r.offices || [])
-          .map((o) => o.name)
-          .filter((n) => n && n !== "Remote")
-          .join(", ");
-        const location = officeNames || r.location?.name || c.city || c.country;
 
-        return {
-          id: `${mode}_gh_${c.slug}_${r.id}`,
-          title: r.title,
-          location,
-          url: r.absolute_url,
-          postedAt: r.updated_at,
-          description: stripHtml(r.content || ""),
-        };
-      }),
-      c,
-      mode,
-    );
-    return { jobs: processed, rawCount, durationMs: Date.now() - t0, ok: true };
-  } catch (e) {
-    return {
-      jobs: [],
-      rawCount: 0,
-      error: `Parse Error: ${e}`,
-      durationMs: Date.now() - t0,
-      ok: false,
-    };
-  }
+  // NOTE: no fallback/shape guard on `jobs` here, unlike teamtailor.ts — that
+  // guard was added because Yodo1 proved the failure live. No Greenhouse
+  // board has shown this shape in practice; adding a speculative guard here
+  // would be unfalsifiable. Flagged, not bundled in, same as this repo's own
+  // convention (see issue-52-429-404-followup-part3.md).
+  const { jobs } = result.data;
+  const rawCount = jobs.length;
+  const processed = processJobs(
+    jobs.map((r) => {
+      const officeNames = (r.offices || [])
+        .map((o) => o.name)
+        .filter((n) => n && n !== "Remote")
+        .join(", ");
+      const location = officeNames || r.location?.name || c.city || c.country;
+
+      return {
+        id: `${mode}_gh_${c.slug}_${r.id}`,
+        title: r.title,
+        location,
+        url: r.absolute_url,
+        postedAt: r.updated_at,
+        description: stripHtml(r.content || ""),
+      };
+    }),
+    c,
+    mode,
+  );
+  return { jobs: processed, rawCount, durationMs: Date.now() - t0, ok: true };
 }

--- a/src/lib/sources/ats/http.ts
+++ b/src/lib/sources/ats/http.ts
@@ -137,19 +137,21 @@ export async function safeFetch(
 }
 
 /**
- * Wraps safeFetch + JSON parsing behind one result type, so callers can't
- * repeat the same three failure modes inconsistently: no response, a non-2xx
- * status, and a 2xx status whose body still isn't JSON (a bot-challenge or
- * WAF page served with HTTP 200 satisfies `res.ok` but crashes `res.json()`).
- * Checking content-type before parsing catches that third case explicitly
- * instead of it surfacing as an ambiguous parse-error further down.
+ * Turns a Response (or null, for a failed fetch) into one result type, so
+ * callers can't repeat the same three failure modes inconsistently: no
+ * response, a non-2xx status, and a 2xx status whose body still isn't JSON
+ * (a bot-challenge or WAF page served with HTTP 200 satisfies `res.ok` but
+ * crashes `res.json()`). Checking content-type before parsing catches that
+ * third case explicitly instead of it surfacing as an ambiguous parse-error
+ * further down.
+ *
+ * Split out from safeFetchJson so callers with their own queued/retried
+ * fetch (e.g. workable.ts's fetchWorkableUrl) can reuse this parsing step
+ * on a Response they already have, instead of duplicating it.
  */
-export async function safeFetchJson<T>(
-  url: string,
-  timeout?: number,
-  extraHeaders?: Record<string, string>,
+export async function parseJsonBody<T>(
+  res: Response | null,
 ): Promise<{ ok: true; data: T } | { ok: false; error: string }> {
-  const res = await safeFetch(url, timeout, extraHeaders);
   if (!res) return { ok: false, error: "Network/Timeout" };
   if (!res.ok) return { ok: false, error: `HTTP ${res.status}` };
 
@@ -168,4 +170,14 @@ export async function safeFetchJson<T>(
   } catch (e) {
     return { ok: false, error: `Parse Error: ${e}` };
   }
+}
+
+/** safeFetch + parseJsonBody in one call, for callers with no queueing of their own. */
+export async function safeFetchJson<T>(
+  url: string,
+  timeout?: number,
+  extraHeaders?: Record<string, string>,
+): Promise<{ ok: true; data: T } | { ok: false; error: string }> {
+  const res = await safeFetch(url, timeout, extraHeaders);
+  return parseJsonBody<T>(res);
 }

--- a/src/lib/sources/ats/lever.ts
+++ b/src/lib/sources/ats/lever.ts
@@ -2,53 +2,39 @@
 // Split out of ats-utils.ts (see AUDIT_STATUS.md row #2) — no behavior change.
 import type { ATSConfig, FetcherResult, LeverJob } from "@/types";
 import type { JobMode } from "@/lib/types";
-import { safeFetch } from "./http";
+import { safeFetchJson } from "./http";
 import { processJobs, stripHtml } from "./job-processing";
 
 export async function fetchLever(c: ATSConfig, mode: JobMode): Promise<FetcherResult> {
   const t0 = Date.now();
   const url = `https://api.lever.co/v0/postings/${c.slug}?mode=json`;
-  const res = await safeFetch(url);
+  const result = await safeFetchJson<LeverJob[]>(url);
 
-  if (!res)
+  if (!result.ok)
     return {
       jobs: [],
       rawCount: 0,
-      error: "Network/Timeout",
+      error: result.error,
       durationMs: Date.now() - t0,
       ok: false,
     };
-  if (!res.ok)
-    return {
-      jobs: [],
-      rawCount: 0,
-      error: `HTTP ${res.status}`,
-      durationMs: Date.now() - t0,
-      ok: false,
-    };
-  try {
-    const jobs = (await res.json()) as LeverJob[];
-    const rawCount = jobs.length;
-    const processed = processJobs(
-      jobs.map((r) => ({
-        id: `${mode}_lever_${c.slug}_${r.id}`,
-        title: r.text,
-        location: r.categories?.location ?? c.city ?? c.country,
-        url: r.hostedUrl,
-        postedAt: new Date(r.createdAt).toISOString(),
-        description: stripHtml(r.description || ""),
-      })),
-      c,
-      mode,
-    );
-    return { jobs: processed, rawCount, durationMs: Date.now() - t0, ok: true };
-  } catch (e) {
-    return {
-      jobs: [],
-      rawCount: 0,
-      error: `Parse Error: ${e}`,
-      durationMs: Date.now() - t0,
-      ok: false,
-    };
-  }
+
+  // NOTE: no shape guard on the body being an array — same latent risk class
+  // as teamtailor.ts's fix, no live evidence for Lever specifically. Flagged,
+  // not bundled in, per this repo's convention (issue-52-429-404-followup-part3.md).
+  const jobs = result.data;
+  const rawCount = jobs.length;
+  const processed = processJobs(
+    jobs.map((r) => ({
+      id: `${mode}_lever_${c.slug}_${r.id}`,
+      title: r.text,
+      location: r.categories?.location ?? c.city ?? c.country,
+      url: r.hostedUrl,
+      postedAt: new Date(r.createdAt).toISOString(),
+      description: stripHtml(r.description || ""),
+    })),
+    c,
+    mode,
+  );
+  return { jobs: processed, rawCount, durationMs: Date.now() - t0, ok: true };
 }

--- a/src/lib/sources/ats/smart-recruiters.ts
+++ b/src/lib/sources/ats/smart-recruiters.ts
@@ -2,66 +2,60 @@
 // Split out of ats-utils.ts (see AUDIT_STATUS.md row #2) — no behavior change.
 import type { ATSConfig, ATSRawInput, FetcherResult, SRJob, SRDetail } from "@/types";
 import type { JobMode } from "@/lib/types";
-import { safeFetch } from "./http";
+import { safeFetch, safeFetchJson } from "./http";
 import { processJobs, stripHtml, pLimit } from "./job-processing";
 
 export async function fetchSmartRecruiters(c: ATSConfig, mode: JobMode): Promise<FetcherResult> {
   const t0 = Date.now();
   const url = `https://api.smartrecruiters.com/v1/companies/${c.slug}/postings`;
-  const res = await safeFetch(url);
+  const result = await safeFetchJson<{ content: SRJob[] }>(url);
 
-  if (!res)
+  if (!result.ok)
     return {
       jobs: [],
       rawCount: 0,
-      error: "Network/Timeout",
+      error: result.error,
       durationMs: Date.now() - t0,
       ok: false,
     };
-  if (!res.ok)
-    return {
-      jobs: [],
-      rawCount: 0,
-      error: `HTTP ${res.status}`,
-      durationMs: Date.now() - t0,
-      ok: false,
-    };
-  try {
-    const { content } = (await res.json()) as { content: SRJob[] };
-    const rawCount = content.length;
-    const detailedJobs = await pLimit(
-      content.map((r) => async () => {
-        const detailRes = await safeFetch(r.ref);
-        if (!detailRes || !detailRes.ok) return null;
-        try {
-          const detail = (await detailRes.json()) as SRDetail;
-          return {
-            id: `${mode}_sr_${c.slug}_${r.id}`,
-            title: r.name,
-            location: r.location.fullLocation ?? c.city ?? c.country,
-            url: `https://jobs.smartrecruiters.com/${c.slug}/${r.id}`,
-            postedAt: r.releasedDate,
-            description: stripHtml(detail.jobAd?.sections?.jobDescription?.content || ""),
-          };
-        } catch {
-          return null;
-        }
-      }),
-      5,
-    );
-    const processed = processJobs(
-      detailedJobs.filter((j): j is ATSRawInput => j !== null),
-      c,
-      mode,
-    );
-    return { jobs: processed, rawCount, durationMs: Date.now() - t0, ok: true };
-  } catch (e) {
-    return {
-      jobs: [],
-      rawCount: 0,
-      error: `Parse Error: ${e}`,
-      durationMs: Date.now() - t0,
-      ok: false,
-    };
-  }
+
+  // NOTE: no shape guard on `content` — same latent risk class as
+  // teamtailor.ts's fix, no live evidence for SmartRecruiters specifically.
+  // Flagged, not bundled in.
+  const { content } = result.data;
+  const rawCount = content.length;
+
+  // Per-job detail fetch is left on the old safeFetch + res.ok + try/catch
+  // pattern on purpose — same carve-out as workable.ts's detail path. A bad
+  // detail response here already degrades without crashing: it returns
+  // `null` and the job is filtered out below. That's a *different* defect
+  // (a job silently dropped, rather than a description falling back to the
+  // list description) — real, but pre-existing and out of scope for this
+  // migration, which targets the list-call crash class only.
+  const detailedJobs = await pLimit(
+    content.map((r) => async () => {
+      const detailRes = await safeFetch(r.ref);
+      if (!detailRes || !detailRes.ok) return null;
+      try {
+        const detail = (await detailRes.json()) as SRDetail;
+        return {
+          id: `${mode}_sr_${c.slug}_${r.id}`,
+          title: r.name,
+          location: r.location.fullLocation ?? c.city ?? c.country,
+          url: `https://jobs.smartrecruiters.com/${c.slug}/${r.id}`,
+          postedAt: r.releasedDate,
+          description: stripHtml(detail.jobAd?.sections?.jobDescription?.content || ""),
+        };
+      } catch {
+        return null;
+      }
+    }),
+    5,
+  );
+  const processed = processJobs(
+    detailedJobs.filter((j): j is ATSRawInput => j !== null),
+    c,
+    mode,
+  );
+  return { jobs: processed, rawCount, durationMs: Date.now() - t0, ok: true };
 }

--- a/src/lib/sources/ats/teamtailor.ts
+++ b/src/lib/sources/ats/teamtailor.ts
@@ -2,53 +2,52 @@
 // Split out of ats-utils.ts (see AUDIT_STATUS.md row #2) — no behavior change.
 import type { ATSConfig, FetcherResult, TeamtailorJob } from "@/types";
 import type { JobMode } from "@/lib/types";
-import { safeFetch } from "./http";
+import { safeFetchJson } from "./http";
 import { processJobs, stripHtml } from "./job-processing";
 
 export async function fetchTeamtailor(c: ATSConfig, mode: JobMode): Promise<FetcherResult> {
   const t0 = Date.now();
   const publicUrl = `https://${c.slug}.teamtailor.com/jobs.json`;
-  const res = await safeFetch(publicUrl, 30_000, { Accept: "application/json" });
+  const result = await safeFetchJson<{ data?: TeamtailorJob[] }>(publicUrl, 30_000, {
+    Accept: "application/json",
+  });
 
-  if (!res)
+  if (!result.ok)
     return {
       jobs: [],
       rawCount: 0,
-      error: "Network/Timeout",
+      error: result.error,
       durationMs: Date.now() - t0,
       ok: false,
     };
-  if (!res.ok)
+
+  // safeFetchJson only confirms the body parsed as JSON — it doesn't confirm
+  // this shape. Yodo1's board (issue-52-429-404-followup-part3.md) returned
+  // valid JSON with no `data` array, which crashed the old `data.length` on
+  // `undefined` — the live bug that put teamtailor first in this rollout.
+  // Guard the shape explicitly instead of trusting it.
+  const jobs = result.data.data;
+  if (!Array.isArray(jobs))
     return {
       jobs: [],
       rawCount: 0,
-      error: `HTTP ${res.status}`,
+      error: "Unexpected response shape: missing `data` array",
       durationMs: Date.now() - t0,
       ok: false,
     };
-  try {
-    const { data } = (await res.json()) as { data: TeamtailorJob[] };
-    const rawCount = data.length;
-    const processed = processJobs(
-      data.map((r) => ({
-        id: `${mode}_tt_${c.slug}_${r.id}`,
-        title: r.attributes.title,
-        location: r.attributes["location-name"] ?? c.city ?? c.country,
-        url: r.attributes["external-url"] || `https://${c.slug}.teamtailor.com/jobs/${r.id}`,
-        postedAt: r.attributes["published-at"],
-        description: stripHtml(r.attributes["body-html"] || ""),
-      })),
-      c,
-      mode,
-    );
-    return { jobs: processed, rawCount, durationMs: Date.now() - t0, ok: true };
-  } catch (e) {
-    return {
-      jobs: [],
-      rawCount: 0,
-      error: `Parse Error: ${e}`,
-      durationMs: Date.now() - t0,
-      ok: false,
-    };
-  }
+
+  const rawCount = jobs.length;
+  const processed = processJobs(
+    jobs.map((r) => ({
+      id: `${mode}_tt_${c.slug}_${r.id}`,
+      title: r.attributes.title,
+      location: r.attributes["location-name"] ?? c.city ?? c.country,
+      url: r.attributes["external-url"] || `https://${c.slug}.teamtailor.com/jobs/${r.id}`,
+      postedAt: r.attributes["published-at"],
+      description: stripHtml(r.attributes["body-html"] || ""),
+    })),
+    c,
+    mode,
+  );
+  return { jobs: processed, rawCount, durationMs: Date.now() - t0, ok: true };
 }

--- a/src/lib/sources/ats/workable.ts
+++ b/src/lib/sources/ats/workable.ts
@@ -2,7 +2,7 @@
 import type { ATSConfig, ATSRawInput, FetcherResult, WorkableJob, WorkableDetail } from "@/types";
 import type { JobMode } from "@/lib/types";
 import { processJobs, stripHtml, pLimit } from "./job-processing";
-import { parseRetryAfterMs } from "./http";
+import { parseRetryAfterMs, parseJsonBody } from "./http";
 import {
   trackDomainRequest,
   isWorkableBlocked,
@@ -157,77 +157,68 @@ export async function fetchWorkable(c: ATSConfig, mode: JobMode): Promise<Fetche
 
   const listUrl = `https://apply.workable.com/api/v1/widget/accounts/${c.slug}?details=true`;
   const res = await fetchWorkableUrl(listUrl, c.slug);
+  const parsed = await parseJsonBody<{ jobs?: WorkableJob[] }>(res);
 
-  if (!res)
+  if (!parsed.ok)
     return {
       jobs: [],
       rawCount: 0,
-      error: "Network/Timeout",
+      error: parsed.error,
       durationMs: Date.now() - t0,
       ok: false,
     };
-  if (!res.ok)
-    return {
-      jobs: [],
-      rawCount: 0,
-      error: `HTTP ${res.status}`,
-      durationMs: Date.now() - t0,
-      ok: false,
-    };
-  try {
-    const data = (await res.json()) as { jobs?: WorkableJob[] };
-    const rawJobs = data.jobs || [];
-    const rawCount = rawJobs.length;
-    // NOTE: title pre-filtering was removed — all jobs now flow through
-    // to the per-user scoring pipeline where filtering actually belongs.
-    // Removed for the same reason as processJobs — role filtering is the
-    // user's call via /settings now, not a hardcoded gate. If Workable detail-fetch
-    // volume becomes a real budget concern, that's a separate, deliberate decision —
-    // not a silent side effect of this filter.
-    const jobs = rawJobs;
-    // A job's detail page can 404/410 between the list call and this fetch
-    // (delisted, stale shortcode) — that's routine board churn, not a fetch
-    // failure. `dr === null` (network error, timeout, or slug blocked
-    // mid-fanout) is deliberately NOT counted here: those already surface
-    // via fetchWorkableUrl's own logging / markWorkable429, and conflating
-    // them with dead-link churn would blur two different problems together.
-    let detailFailures = 0;
-    const withDesc = await pLimit(
-      jobs.map((r) => async () => {
-        const detailUrl = `https://apply.workable.com/api/v1/widget/accounts/${c.slug}/jobs/${r.shortcode}`;
-        const dr = isWorkableBlocked(c.slug) ? null : await fetchWorkableUrl(detailUrl, c.slug);
-        const { description, detailFailed } = await resolveJobDescription(
-          dr,
-          stripHtml(r.description || ""),
-        );
-        if (detailFailed) detailFailures += 1;
-        return {
-          id: `${mode}_workable_${c.slug}_${r.shortcode}`,
-          title: r.title,
-          location: r.city ?? c.city ?? c.country,
-          url: r.url,
-          postedAt: r.published_on,
-          description,
-        };
-      }),
-      5,
-    );
-    const processed = processJobs(withDesc.filter(Boolean) as ATSRawInput[], c, mode);
-    const warnings =
-      detailFailures > 0
-        ? [
-            `${detailFailures}/${jobs.length} job detail fetches failed (dead/removed links) — used list description as fallback`,
-          ]
-        : undefined;
 
-    return { jobs: processed, rawCount, warnings, durationMs: Date.now() - t0, ok: true };
-  } catch (e) {
-    return {
-      jobs: [],
-      rawCount: 0,
-      error: `Parse Error: ${e}`,
-      durationMs: Date.now() - t0,
-      ok: false,
-    };
-  }
+  const rawJobs = parsed.data.jobs || [];
+  const rawCount = rawJobs.length;
+  // NOTE: title pre-filtering was removed — all jobs now flow through
+  // to the per-user scoring pipeline where filtering actually belongs.
+  // Removed for the same reason as processJobs — role filtering is the
+  // user's call via /settings now, not a hardcoded gate. If Workable detail-fetch
+  // volume becomes a real budget concern, that's a separate, deliberate decision —
+  // not a silent side effect of this filter.
+  const jobs = rawJobs;
+  // A job's detail page can 404/410 between the list call and this fetch
+  // (delisted, stale shortcode) — that's routine board churn, not a fetch
+  // failure. `dr === null` (network error, timeout, or slug blocked
+  // mid-fanout) is deliberately NOT counted here: those already surface
+  // via fetchWorkableUrl's own logging / markWorkable429, and conflating
+  // them with dead-link churn would blur two different problems together.
+  //
+  // The detail-fetch path below stays on its own inline .json()/try-catch
+  // (resolveJobDescription) rather than parseJsonBody, on purpose: it
+  // already degrades gracefully (falls back to the list description,
+  // counted as a warning, from 362bdd8) on any bad response, so it isn't
+  // the crash class this migration targets, and parseJsonBody's stricter
+  // content-type check would turn today's "fallback to list description"
+  // outcome into an identical outcome by a longer path for no gain.
+  let detailFailures = 0;
+  const withDesc = await pLimit(
+    jobs.map((r) => async () => {
+      const detailUrl = `https://apply.workable.com/api/v1/widget/accounts/${c.slug}/jobs/${r.shortcode}`;
+      const dr = isWorkableBlocked(c.slug) ? null : await fetchWorkableUrl(detailUrl, c.slug);
+      const { description, detailFailed } = await resolveJobDescription(
+        dr,
+        stripHtml(r.description || ""),
+      );
+      if (detailFailed) detailFailures += 1;
+      return {
+        id: `${mode}_workable_${c.slug}_${r.shortcode}`,
+        title: r.title,
+        location: r.city ?? c.city ?? c.country,
+        url: r.url,
+        postedAt: r.published_on,
+        description,
+      };
+    }),
+    5,
+  );
+  const processed = processJobs(withDesc.filter(Boolean) as ATSRawInput[], c, mode);
+  const warnings =
+    detailFailures > 0
+      ? [
+          `${detailFailures}/${jobs.length} job detail fetches failed (dead/removed links) — used list description as fallback`,
+        ]
+      : undefined;
+
+  return { jobs: processed, rawCount, warnings, durationMs: Date.now() - t0, ok: true };
 }


### PR DESCRIPTION
Closes priorities 1 and 2 from issue-52-429-404-followup-part3.md's
remaining-work list. Full rationale, the discarded-commits detour, and the
per-fetcher scope decisions are in issue-52-429-404-followup-part4.md —
this message summarizes.

safeFetchJson rollout (priority 1):
- http.ts: split safeFetchJson into parseJsonBody(res: Response | null) +
  a thin safeFetch-calling wrapper, so workable.ts (which queues/retries
  its own fetch) can reuse the parsing step without duplicating it.
- teamtailor.ts, ashby.ts, greenhouse.ts, lever.ts, smart-recruiters.ts,
  bamboohr.ts: migrated off res.ok + bare res.json() to safeFetchJson.
- teamtailor.ts additionally gained an explicit Array.isArray guard on the
  parsed body's `data` field. safeFetchJson only confirms the body parsed
  as JSON, not that it matches the expected shape — Yodo1's board (part 3)
  returned valid JSON with no `data` array, crashing the old
  `data.length` on `undefined`. A blind safeFetchJson swap would have
  moved that same crash from an inner try/catch to ats-bridge.ts's outer
  catch, not fixed it. New test: teamtailor-shape-guard.test.ts.
- No equivalent guard added to greenhouse.ts, lever.ts, or
  smart-recruiters.ts, which have the same latent no-fallback shape-trust
  pattern — flagged in-code, not fixed, with no live evidence of it
  firing for those three.
- workable.ts: list-call only, calling parseJsonBody directly on
  fetchWorkableUrl's Response. Detail-fetch path (resolveJobDescription)
  left untouched, per part 3's carve-out — it already degrades
  gracefully, so this isn't the crash class this rollout targets.
  bamboohr.ts's and smart-recruiters.ts's per-job detail-fetch loops get
  the same carve-out for the same reason. Noted separately:
  smart-recruiters.ts's detail loop silently drops a job entirely on a
  bad response (returns null, filtered out) rather than falling back to
  a list-level description — pre-existing, real, out of scope here.
- Updated 3 existing test mocks (ats-utils-tracking.test.ts,
  workable-detail-warnings.test.ts, workable-rate-limit.test.ts) that
  simulated list responses without a content-type header or a .text()
  method — safeFetchJson/parseJsonBody need both; the old res.json()
  pattern needed neither. This is the mock catching up to what a real
  successful JSON response looks like, not a weakened test.
- Live per-company verification (pnpm cron:log against each real board)
  is NOT done here — no network route to these ATS hosts and no Supabase
  credentials from this session's sandbox, and this repo has no dry-run
  mode. Verified instead via tsc --noEmit, eslint, and the full vitest
  suite (379/379, 2 new).

ATS_TYPES extraction (priority 2):
- submit/page.tsx: moved the inline ATS_TYPES array (react-component-
  architecture violation — constants always move out of component files)
  into lib/constants.ts, next to the existing VALID_ATS. No new file, no
  behavior change.

Docs updated: CHANGELOG.md, docs/ARCHITECTURE.md (§7 ATS ingestion layer),
issue-52-429-404-followup-part3.md (remaining-work list marked done,
new item 8 added for the flagged-not-fixed gaps), new
issue-52-429-404-followup-part4.md (full session record).