### PR TITLE
feat(pipeline): per-gate job breakdown, ingestion-loss visibility, job-trace search

### DIFF
--- a/e2e/pipeline.spec.ts
+++ b/e2e/pipeline.spec.ts
@@ -23,69 +23,63 @@ test.describe("pipeline — funnel visualisation", () => {
     await expect(page.getByRole("heading").first()).toBeVisible({ timeout: 8_000 });
   });
 
-  test("pipeline renders stage counters — fetched → date-filtered → settings-filtered → AI-filtered", async ({
-    page,
-  }) => {
+  // UPDATED: buildFeed no longer lumps seniority/keyword/location/skill gates
+  // into one "Settings filter" — they're individually tracked accordion rows
+  // now (see GATE_META in FunnelView.tsx). "Fetched"/"total" became "Scraped
+  // this run" / "Matched your pipelines" / "In candidate window".
+  test("pipeline renders its top-level stage labels", async ({ page }) => {
     await page.goto("/pipeline");
     await page.waitForLoadState("networkidle");
 
-    // The pipeline funnel shows how many jobs survived each filtering stage.
     // Numbers may be 0 if the cache hasn't been built yet, but the labels
     // for each stage should still be present.
-    const hasFetched = await page
-      .getByText(/fetched|total/i)
+    const hasTopFunnel = await page
+      .getByText(/scraped|matched your pipelines|candidate window/i)
       .first()
       .isVisible()
       .catch(() => false);
-    const hasDateFilter = await page
-      .getByText(/date|age/i)
+    const hasDateGate = await page
+      .getByText(/date filter/i)
       .first()
       .isVisible()
       .catch(() => false);
-    const hasSettingsFilter = await page
-      .getByText(/settings|filter/i)
+    // Any one of the 5 gates that used to be lumped into "Settings filter" is
+    // enough to confirm the split happened.
+    const hasSplitSettingsGate = await page
+      .getByText(
+        /seniority filter|excluded keyword|required keyword|blacklisted location|skill match/i,
+      )
       .first()
       .isVisible()
       .catch(() => false);
     const hasAiFilter = await page
-      .getByText(/gemini|ai|llm/i)
+      .getByText(/gemini/i)
       .first()
       .isVisible()
       .catch(() => false);
 
-    // At least two of the four stage labels must be visible
-    const visibleStageCount = [hasFetched, hasDateFilter, hasSettingsFilter, hasAiFilter].filter(
+    const visibleStageCount = [hasTopFunnel, hasDateGate, hasSplitSettingsGate, hasAiFilter].filter(
       Boolean,
     ).length;
     expect(visibleStageCount).toBeGreaterThanOrEqual(2);
   });
 
-  // FIX: The previous version of this test checked for "visa / local / global" text
-  // on the pipeline page. FunnelView does NOT render a per-pipeline breakdown —
-  // it shows stage labels: "Fetched", "Date filter", "Settings filter", "Your Gemini filter".
-  // The pipeline mode names (visa/local/global) only appear in SettingsForm and on
-  // the dashboard filter tabs, not in the funnel visualisation.
-  //
-  // This test is rewritten to verify what FunnelView actually renders:
-  // the four funnel stage nodes. Separately, the filter-tab test in
-  // dashboard.spec.ts covers the mode (visa/local/global) label rendering.
-  test("pipeline funnel renders the four stage nodes", async ({ page }) => {
+  // UPDATED: the funnel is now three connected tiles ("Scraped this run" →
+  // "Matched your pipelines" → "In candidate window"), not four flat stage
+  // nodes ("Fetched" / "Date filter" / ...) — date/seniority/keywords/etc.
+  // moved down into the per-gate accordion list below the funnel.
+  test("pipeline funnel renders the top three connected tiles", async ({ page }) => {
     await page.goto("/pipeline");
     await page.waitForLoadState("networkidle");
 
-    // FunnelView shows four stage nodes. Each stage has a label rendered
-    // via the STAGES constant in FunnelView.tsx:
-    //   "Fetched" | "Date filter" | "Settings filter" | "Your Gemini filter"
-    // If the cache has not been built yet, FunnelView renders an empty-state
-    // message instead — we accept either outcome.
-    const hasFunnelNodes =
+    const hasFunnelTiles =
       (await page
-        .getByText(/fetched/i)
+        .getByText(/scraped this run/i)
         .first()
         .isVisible()
         .catch(() => false)) &&
       (await page
-        .getByText(/date filter/i)
+        .getByText(/matched your pipelines/i)
         .first()
         .isVisible()
         .catch(() => false));
@@ -96,15 +90,27 @@ test.describe("pipeline — funnel visualisation", () => {
       .isVisible()
       .catch(() => false);
 
-    // One of the two states must be true — funnel nodes OR empty-state message.
-    expect(hasFunnelNodes || hasEmptyState).toBe(true);
+    // One of the two states must be true — funnel tiles OR empty-state message.
+    expect(hasFunnelTiles || hasEmptyState).toBe(true);
+  });
+
+  // NEW: the job-trace search box ("can't find it in the lists above?") is
+  // always rendered regardless of whether the cache has data yet — it
+  // queries raw_jobs directly and doesn't depend on pipeline_log.
+  test("job-trace search box is present with title and company inputs", async ({ page }) => {
+    await page.goto("/pipeline");
+    await page.waitForLoadState("networkidle");
+
+    await expect(page.getByPlaceholder(/job title/i)).toBeVisible();
+    await expect(page.getByPlaceholder(/company/i)).toBeVisible();
+    await expect(page.getByRole("button", { name: /search/i })).toBeVisible();
   });
 
   // FIX: The API response shape is { ok: true, data: { pipeline_log, jobs, ... } }.
   // pipeline_log and jobs live under the `data` key, not at the top level.
-  // The previous test used expect(body).toHaveProperty("pipeline_log") which
-  // looked at the root object and found nothing; the correct path is body.data.
-  test("/api/dashboard response is 200 and contains pipeline_log", async ({ page }) => {
+  test("/api/dashboard response is 200 and contains the new pipeline_log shape", async ({
+    page,
+  }) => {
     // Directly verify the API that feeds the pipeline page
     const response = await page.request.get("/api/dashboard");
     expect(response.status()).toBe(200);
@@ -116,5 +122,25 @@ test.describe("pipeline — funnel visualisation", () => {
     expect(body.data).toHaveProperty("pipeline_log");
     expect(body.data).toHaveProperty("jobs");
     expect(Array.isArray(body.data.jobs)).toBe(true);
+
+    // Structural check on the new shape — top-level funnel counts and the
+    // 9-gate breakdown, not the old 5 flat integers.
+    const log = body.data.pipeline_log;
+    expect(log).toHaveProperty("total_scraped");
+    expect(log).toHaveProperty("matched_pipelines");
+    expect(log).toHaveProperty("candidate_window");
+    expect(log).toHaveProperty("on_dashboard");
+    expect(log).toHaveProperty("wrong_pipeline_mode");
+    expect(log).toHaveProperty("outside_candidate_window");
+    expect(log.gates).toHaveProperty("date");
+    expect(log.gates).toHaveProperty("gemini");
+    expect(log.gates).toHaveProperty("scoring");
+  });
+
+  // NEW: smoke-tests the search API directly — a query with neither title
+  // nor company must be rejected before it ever reaches raw_jobs.
+  test("/api/jobs/explain requires a title or company", async ({ page }) => {
+    const response = await page.request.get("/api/jobs/explain");
+    expect(response.status()).toBe(400);
   });
 });

--- a/src/app/(protected)/pipeline/page.tsx
+++ b/src/app/(protected)/pipeline/page.tsx
@@ -3,6 +3,7 @@
 
 import { useState, useEffect } from "react";
 import FunnelView from "@/components/pipeline/FunnelView";
+import JobTraceSearch from "@/components/pipeline/JobTraceSearch";
 import type { PipelineLog } from "@/lib/types";
 
 export default function PipelinePage() {
@@ -19,5 +20,12 @@ export default function PipelinePage() {
     })();
   }, []);
 
-  return <FunnelView log={log} loading={loading} />;
+  return (
+    <>
+      <FunnelView log={log} loading={loading} />
+      <div className="px-8 pb-8">
+        <JobTraceSearch />
+      </div>
+    </>
+  );
 }

--- a/src/app/api/dashboard/route.test.ts
+++ b/src/app/api/dashboard/route.test.ts
@@ -1,0 +1,256 @@
+// src/app/api/dashboard/route.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ResolvedSettings } from "@/lib/types";
+
+const mockServerDb = { from: vi.fn() };
+const mockAdminDb = { from: vi.fn() };
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerClient: () => mockServerDb,
+  getUser: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => mockAdminDb,
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: () => ({ getAll: () => [], set: () => {} }),
+}));
+
+vi.mock("@/lib/settings", () => ({
+  resolveUserSettings: vi.fn(),
+}));
+
+vi.mock("@/lib/runner", () => ({
+  isCacheFresh: vi.fn(),
+}));
+
+vi.mock("@/lib/dashboard-route", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/dashboard-route")>("@/lib/dashboard-route");
+  return {
+    ...actual,
+    buildFeed: vi.fn(),
+  };
+});
+
+function mockSingleQuery(data: unknown, error: unknown = null) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    upsert: vi.fn().mockResolvedValue({ data, error }),
+    single: vi.fn().mockResolvedValue({ data, error }),
+    then: (resolve: (v: { data: unknown; error: unknown }) => void) => resolve({ data, error }),
+  };
+}
+
+// Chainable, awaitable raw_jobs query builder — `.in()` is recorded so tests
+// can assert which mode set a given query used.
+function makeRawJobsQuery(result: { data: unknown; count?: number | null; error?: unknown }) {
+  const calls: { method: string; args: unknown[] }[] = [];
+  const builder: Record<string, unknown> = {
+    select: vi.fn((...args: unknown[]) => {
+      calls.push({ method: "select", args });
+      return builder;
+    }),
+    in: vi.fn((...args: unknown[]) => {
+      calls.push({ method: "in", args });
+      return builder;
+    }),
+    order: vi.fn(() => builder),
+    limit: vi.fn(() => builder),
+    range: vi.fn(() => builder),
+    then: (resolve: (v: unknown) => void) =>
+      resolve({ data: result.data, count: result.count ?? null, error: result.error ?? null }),
+    __calls: calls,
+  };
+  return builder;
+}
+
+function makeSettings(overrides: Partial<ResolvedSettings> = {}): ResolvedSettings {
+  return {
+    expert_skills: ["React"],
+    secondary_skills: [],
+    bonus_skills: [],
+    job_age_days: 30,
+    pipeline_local: true,
+    pipeline_global: true,
+    seniority_levels: ["senior"],
+    junior_keywords: ["junior"],
+    mid_keywords: ["mid"],
+    senior_keywords: ["senior"],
+    staff_keywords: ["staff"],
+    excluded_keywords: [],
+    required_keywords: [],
+    blacklisted_locations: [],
+    gemini_filter_prompt: "",
+    scoring_weights: { skill: 0.5, recency: 0.3, relocation: 0.2 },
+    score_denominator: 10,
+    global_mode_blocked_regions: [],
+    global_mode_allowed_locations: [],
+    email_alerts_enabled: true,
+    salary_reminder_enabled: false,
+    ...overrides,
+  } as ResolvedSettings;
+}
+
+const mockUser = { id: "user-123", email: "test@example.com" };
+const emptyGateLog = {
+  candidate_window: 0,
+  on_dashboard: 0,
+  gates: {
+    date: { count: 0, sample: [] },
+    seniority: { count: 0, sample: [] },
+    excluded_keywords: { count: 0, sample: [] },
+    required_keywords: { count: 0, sample: [] },
+    blacklisted_locations: { count: 0, sample: [] },
+    skill_match: { count: 0, sample: [] },
+    global_mode: { count: 0, sample: [] },
+    gemini: { count: 0, sample: [] },
+    scoring: { count: 0, sample: [] },
+  },
+};
+
+describe("GET /api/dashboard", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { getUser } = await import("@/lib/supabase/server");
+    (getUser as ReturnType<typeof vi.fn>).mockResolvedValue(mockUser);
+    const { resolveUserSettings } = await import("@/lib/settings");
+    (resolveUserSettings as ReturnType<typeof vi.fn>).mockResolvedValue(makeSettings());
+    const { buildFeed } = await import("@/lib/dashboard-route");
+    (buildFeed as ReturnType<typeof vi.fn>).mockResolvedValue({
+      finalJobs: [],
+      gateLog: emptyGateLog,
+    });
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const { getUser } = await import("@/lib/supabase/server");
+    (getUser as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const { GET } = await import("./route");
+    const res = await GET();
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns the cached pipeline_log unchanged on a cache hit, without querying raw_jobs", async () => {
+    const { isCacheFresh } = await import("@/lib/runner");
+    (isCacheFresh as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    const cachedLog = { ...emptyGateLog, cached_at: "2026-01-01T00:00:00Z" };
+    mockServerDb.from.mockReturnValue(
+      mockSingleQuery({ jobs: [], pipeline_log: cachedLog, cached_at: "2026-01-01T00:00:00Z" }),
+    );
+
+    const { GET } = await import("./route");
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.data.from_cache).toBe(true);
+    expect(body.data.pipeline_log).toEqual(cachedLog);
+    expect(mockAdminDb.from).not.toHaveBeenCalled();
+  });
+
+  it("computes wrong_pipeline_mode and outside_candidate_window counts from the ingestion queries", async () => {
+    const { isCacheFresh } = await import("@/lib/runner");
+    (isCacheFresh as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    mockServerDb.from.mockReturnValue(mockSingleQuery({ gemini_api_key: null }));
+
+    let rawJobsCall = 0;
+    mockAdminDb.from.mockImplementation((table: string) => {
+      if (table === "app_config") return mockSingleQuery({ last_cron_at: "2026-01-01" });
+      // Call order matches the Promise.all array in route.ts: candidate pool,
+      // total count, matched-pipelines count, wrong-mode sample, outside-window sample.
+      const responses = [
+        { data: [] }, // candidate pool (rawJobsData) — irrelevant to this test
+        { data: null, count: 2200 }, // total_scraped
+        { data: null, count: 2100 }, // matched_pipelines
+        { data: [] }, // wrong_pipeline_mode sample
+        { data: [] }, // outside_candidate_window sample
+      ];
+      const response = responses[rawJobsCall] ?? { data: [] };
+      rawJobsCall += 1;
+      return makeRawJobsQuery(response);
+    });
+
+    const { GET } = await import("./route");
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.data.pipeline_log.total_scraped).toBe(2200);
+    expect(body.data.pipeline_log.matched_pipelines).toBe(2100);
+    // wrong_pipeline_mode = total_scraped - matched_pipelines
+    expect(body.data.pipeline_log.wrong_pipeline_mode.count).toBe(100);
+    // outside_candidate_window = matched_pipelines - 2000, clamped at 0
+    expect(body.data.pipeline_log.outside_candidate_window.count).toBe(100);
+  });
+
+  it("skips the wrong-mode sample query entirely when both pipelines are enabled", async () => {
+    const { isCacheFresh } = await import("@/lib/runner");
+    (isCacheFresh as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    mockServerDb.from.mockReturnValue(mockSingleQuery({ gemini_api_key: null }));
+
+    let rawJobsCall = 0;
+    const inCalls: unknown[][] = [];
+    mockAdminDb.from.mockImplementation((table: string) => {
+      if (table === "app_config") return mockSingleQuery({ last_cron_at: null });
+      const responses = [
+        { data: [] },
+        { data: null, count: 500 },
+        { data: null, count: 500 }, // matched === total → nothing outside any mode
+        { data: [] },
+        { data: [] },
+      ];
+      const response = responses[rawJobsCall] ?? { data: [] };
+      rawJobsCall += 1;
+      const builder = makeRawJobsQuery(response);
+      const originalIn = builder.in as (...args: unknown[]) => unknown;
+      builder.in = (...args: unknown[]) => {
+        inCalls.push(args);
+        return originalIn(...args);
+      };
+      return builder;
+    });
+
+    const { GET } = await import("./route");
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.data.pipeline_log.wrong_pipeline_mode.count).toBe(0);
+    expect(body.data.pipeline_log.wrong_pipeline_mode.sample).toEqual([]);
+    // Only 4 real `.in("mode", ...)` calls should happen (pool, matched-count,
+    // outside-window) — the wrong-mode sample query is skipped in JS entirely
+    // when disabledModes is empty, not sent as an empty-array query.
+    expect(inCalls.length).toBeLessThanOrEqual(4);
+  });
+
+  it("clamps outside_candidate_window at 0 when matched_pipelines is under the 2000 cap", async () => {
+    const { isCacheFresh } = await import("@/lib/runner");
+    (isCacheFresh as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    mockServerDb.from.mockReturnValue(mockSingleQuery({ gemini_api_key: null }));
+
+    let rawJobsCall = 0;
+    mockAdminDb.from.mockImplementation((table: string) => {
+      if (table === "app_config") return mockSingleQuery({ last_cron_at: null });
+      const responses = [
+        { data: [] },
+        { data: null, count: 300 },
+        { data: null, count: 300 },
+        { data: [] },
+        { data: [] },
+      ];
+      const response = responses[rawJobsCall] ?? { data: [] };
+      rawJobsCall += 1;
+      return makeRawJobsQuery(response);
+    });
+
+    const { GET } = await import("./route");
+    const res = await GET();
+    const body = await res.json();
+
+    expect(body.data.pipeline_log.outside_candidate_window.count).toBe(0);
+  });
+});

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -15,8 +15,19 @@ import { dbErrorResponse } from "@/lib/api-errors";
 import { resolveUserSettings } from "@/lib/settings";
 import { isCacheFresh } from "@/lib/runner";
 import { buildFeed, enabledModes } from "@/lib/dashboard-route";
-import type { RawJob, ScoredJob, PipelineLog } from "@/lib/types";
+import type {
+  RawJob,
+  ScoredJob,
+  PipelineLog,
+  IngestionLog,
+  JobMode,
+  WrongModeEntry,
+  OutsideWindowEntry,
+} from "@/lib/types";
+import { MAX_PIPELINE_SAMPLE } from "@/lib/types";
 import type { Json } from "@/lib/database.types";
+
+const ALL_MODES: JobMode[] = ["local", "global"];
 
 export const maxDuration = 60; // Vercel: allow up to 60s for Gemini filter
 
@@ -67,24 +78,80 @@ export async function GET() {
     }
   }
 
-  // ── Fetch raw jobs for enabled pipelines ─────────────────────
-  const { data: rawJobsData, error: rawError } = await adminDb
-    .from("raw_jobs")
-    .select("*")
-    .in("mode", enabledModes(settings))
-    .order("fetched_at", { ascending: false })
-    .limit(2000); // hard cap to keep Gemini context manageable
+  // ── Fetch raw jobs for enabled pipelines, plus everything needed to
+  //    explain ingestion-level losses that happen before any gate runs ────
+  const enabled = enabledModes(settings);
+  const disabledModes = ALL_MODES.filter((m) => !enabled.includes(m));
+
+  const [
+    { data: rawJobsData, error: rawError },
+    { count: totalScraped },
+    { count: matchedPipelines },
+    { data: wrongModeSample },
+    { data: outsideWindowSample },
+  ] = await Promise.all([
+    adminDb
+      .from("raw_jobs")
+      .select("*")
+      .in("mode", enabled)
+      .order("fetched_at", { ascending: false })
+      .limit(2000), // hard cap to keep Gemini context manageable
+    adminDb.from("raw_jobs").select("*", { count: "exact", head: true }),
+    adminDb.from("raw_jobs").select("*", { count: "exact", head: true }).in("mode", enabled),
+    // Jobs whose mode isn't one of the user's enabled pipelines — never seen
+    // by any gate. Skipped entirely when nothing is disabled (nothing to find).
+    disabledModes.length > 0
+      ? adminDb
+          .from("raw_jobs")
+          .select("id, title, company, mode")
+          .in("mode", disabledModes)
+          .order("fetched_at", { ascending: false })
+          .limit(MAX_PIPELINE_SAMPLE)
+      : Promise.resolve({ data: [] as WrongModeEntry[] }),
+    // Jobs that matched the user's mode(s) but rank past the 2000-row cap —
+    // same filter/order as the main query, shifted past row 2000.
+    adminDb
+      .from("raw_jobs")
+      .select("id, title, company, fetched_at")
+      .in("mode", enabled)
+      .order("fetched_at", { ascending: false })
+      .range(2000, 2000 + MAX_PIPELINE_SAMPLE - 1),
+  ]);
 
   if (rawError) {
     return dbErrorResponse("dashboard:GET", rawError);
   }
 
-  // ── Run pipeline (date → settings → global-mode → Gemini → score → merge) ─
-  const { finalJobs, pipelineLog } = await buildFeed(
+  // These are supplementary breakdown numbers, not the core candidate pool —
+  // best-effort rather than failing the whole dashboard load if one of them
+  // errors (e.g. a transient count-query issue shouldn't block someone's jobs).
+  const matchedPipelinesCount = matchedPipelines ?? rawJobsData?.length ?? 0;
+  const ingestionLog: IngestionLog = {
+    total_scraped: totalScraped ?? matchedPipelinesCount,
+    matched_pipelines: matchedPipelinesCount,
+    wrong_pipeline_mode: {
+      count: Math.max(0, (totalScraped ?? matchedPipelinesCount) - matchedPipelinesCount),
+      enabled_pipelines: enabled,
+      sample: (wrongModeSample ?? []) as WrongModeEntry[],
+    },
+    outside_candidate_window: {
+      count: Math.max(0, matchedPipelinesCount - 2000),
+      sample: (outsideWindowSample ?? []) as OutsideWindowEntry[],
+    },
+  };
+
+  // ── Run pipeline (date → gates → global-mode → Gemini → score → merge) ─
+  const { finalJobs, gateLog } = await buildFeed(
     (rawJobsData ?? []) as RawJob[],
     settings,
     profile?.gemini_api_key,
   );
+
+  const pipelineLog: PipelineLog = {
+    ...ingestionLog,
+    ...gateLog,
+    cached_at: new Date().toISOString(),
+  };
 
   // ── Write cache ──────────────────────────────────────────────
   const { data: appConfig } = await adminDb

--- a/src/app/api/jobs/explain/route.test.ts
+++ b/src/app/api/jobs/explain/route.test.ts
@@ -1,0 +1,225 @@
+// src/app/api/jobs/explain/route.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { RawJob, ResolvedSettings } from "@/lib/types";
+
+const mockServerDb = { from: vi.fn() };
+const mockAdminDb = { from: vi.fn() };
+
+vi.mock("@/lib/supabase/server", () => ({
+  createServerClient: () => mockServerDb,
+  getUser: vi.fn(),
+}));
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => mockAdminDb,
+}));
+
+vi.mock("next/headers", () => ({
+  cookies: () => ({ getAll: () => [], set: () => {} }),
+}));
+
+vi.mock("@/lib/settings", () => ({
+  resolveUserSettings: vi.fn(),
+}));
+
+vi.mock("@/lib/gemini", () => ({
+  filterJobsWithGeminiVerbose: vi.fn(),
+}));
+
+function mockProfileQuery(data: unknown, error: unknown = null) {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data, error }),
+  };
+}
+
+// Supabase's query builder is itself awaitable — chain methods return the
+// same builder, and `await query` resolves via `.then()`.
+function makeRawJobsQuery(result: { data: unknown; error: unknown }) {
+  const builder: {
+    select: ReturnType<typeof vi.fn>;
+    order: ReturnType<typeof vi.fn>;
+    limit: ReturnType<typeof vi.fn>;
+    ilike: ReturnType<typeof vi.fn>;
+    then: (resolve: (value: typeof result) => void) => void;
+  } = {
+    select: vi.fn(() => builder),
+    order: vi.fn(() => builder),
+    limit: vi.fn(() => builder),
+    ilike: vi.fn(() => builder),
+    then: (resolve) => resolve(result),
+  };
+  return builder;
+}
+
+function makeJob(overrides: Partial<RawJob> = {}): RawJob {
+  return {
+    id: "job-1",
+    title: "Senior Frontend Engineer",
+    company: "Acme Corp",
+    location: "London, UK",
+    country: "GB",
+    country_flag: "🇬🇧",
+    url: "https://jobs.example.com/1",
+    description: "We need a React and TypeScript expert",
+    posted_at: new Date().toISOString(),
+    fetched_at: new Date().toISOString(),
+    date_unknown: false,
+    is_remote: false,
+    salary: null,
+    mode: "global",
+    visa_sponsorship: false,
+    source_name: "Acme",
+    ats_type: "greenhouse",
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeSettings(overrides: Partial<ResolvedSettings> = {}): ResolvedSettings {
+  return {
+    expert_skills: ["React", "TypeScript"],
+    secondary_skills: [],
+    bonus_skills: [],
+    job_age_days: 365,
+    pipeline_local: true,
+    pipeline_global: true,
+    seniority_levels: ["senior"],
+    junior_keywords: ["junior"],
+    mid_keywords: ["mid"],
+    senior_keywords: ["senior"],
+    staff_keywords: ["staff"],
+    excluded_keywords: [],
+    required_keywords: [],
+    blacklisted_locations: [],
+    gemini_filter_prompt: "",
+    scoring_weights: { skill: 0.5, recency: 0.3, relocation: 0.2 },
+    score_denominator: 10,
+    global_mode_blocked_regions: [],
+    global_mode_allowed_locations: [],
+    email_alerts_enabled: true,
+    salary_reminder_enabled: false,
+    ...overrides,
+  } as ResolvedSettings;
+}
+
+const mockUser = { id: "user-123", email: "test@example.com" };
+
+describe("GET /api/jobs/explain", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { getUser } = await import("@/lib/supabase/server");
+    (getUser as ReturnType<typeof vi.fn>).mockResolvedValue(mockUser);
+    const { resolveUserSettings } = await import("@/lib/settings");
+    (resolveUserSettings as ReturnType<typeof vi.fn>).mockResolvedValue(makeSettings());
+    mockServerDb.from.mockReturnValue(mockProfileQuery({ gemini_api_key: null }));
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    const { getUser } = await import("@/lib/supabase/server");
+    (getUser as ReturnType<typeof vi.fn>).mockResolvedValue(null);
+
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://localhost/api/jobs/explain?title=engineer"));
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when neither title nor company is provided", async () => {
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://localhost/api/jobs/explain"));
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+  });
+
+  it("traces a matched job and stops at the first failing gate", async () => {
+    const job = makeJob({ title: "Senior Sales Manager" });
+    mockAdminDb.from.mockReturnValue(makeRawJobsQuery({ data: [job], error: null }));
+    const { resolveUserSettings } = await import("@/lib/settings");
+    (resolveUserSettings as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeSettings({ excluded_keywords: ["sales"] }),
+    );
+
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://localhost/api/jobs/explain?title=sales"));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.matches).toHaveLength(1);
+    expect(body.data.matches[0].stopped_at).toBe("excluded_keywords");
+    expect(body.data.matches[0].pipeline_match).toBe(true);
+
+    const { filterJobsWithGeminiVerbose } = await import("@/lib/gemini");
+    expect(filterJobsWithGeminiVerbose).not.toHaveBeenCalled();
+  });
+
+  it("flags pipeline_match: false for a job whose mode isn't enabled, while still tracing its gates", async () => {
+    const job = makeJob({ mode: "global", title: "Senior Sales Manager" });
+    mockAdminDb.from.mockReturnValue(makeRawJobsQuery({ data: [job], error: null }));
+    const { resolveUserSettings } = await import("@/lib/settings");
+    (resolveUserSettings as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeSettings({ pipeline_global: false, excluded_keywords: ["sales"] }),
+    );
+
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://localhost/api/jobs/explain?title=sales"));
+    const body = await res.json();
+
+    expect(body.data.matches[0].pipeline_match).toBe(false);
+    // Gate tracing still runs regardless of pipeline match.
+    expect(body.data.matches[0].stopped_at).toBe("excluded_keywords");
+  });
+
+  it("marks gemini_pending when a job clears every gate but the user has no Gemini key", async () => {
+    const job = makeJob();
+    mockAdminDb.from.mockReturnValue(makeRawJobsQuery({ data: [job], error: null }));
+    mockServerDb.from.mockReturnValue(mockProfileQuery({ gemini_api_key: null }));
+
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://localhost/api/jobs/explain?title=Senior"));
+    const body = await res.json();
+
+    expect(body.data.matches[0].gemini_pending).toBe(true);
+    expect(body.data.matches[0].stopped_at).toBeNull();
+    const { filterJobsWithGeminiVerbose } = await import("@/lib/gemini");
+    expect(filterJobsWithGeminiVerbose).not.toHaveBeenCalled();
+  });
+
+  it("fetches a live Gemini decision for a job that clears every earlier gate", async () => {
+    const job = makeJob();
+    mockAdminDb.from.mockReturnValue(makeRawJobsQuery({ data: [job], error: null }));
+    mockServerDb.from.mockReturnValue(mockProfileQuery({ gemini_api_key: "user-key" }));
+    const { filterJobsWithGeminiVerbose } = await import("@/lib/gemini");
+    (filterJobsWithGeminiVerbose as ReturnType<typeof vi.fn>).mockResolvedValue([
+      {
+        id: job.id,
+        pass: false,
+        reason: "Not a fit per your prompt",
+        reviewed: true,
+        quotaExhausted: false,
+      },
+    ]);
+
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://localhost/api/jobs/explain?title=Senior"));
+    const body = await res.json();
+
+    expect(filterJobsWithGeminiVerbose).toHaveBeenCalledWith("user-key", [job], expect.anything());
+    expect(body.data.matches[0].stopped_at).toBe("gemini");
+    expect(body.data.matches[0].gemini_pending).toBe(false);
+  });
+
+  it("returns an empty matches array when nothing in the raw pool matches", async () => {
+    mockAdminDb.from.mockReturnValue(makeRawJobsQuery({ data: [], error: null }));
+
+    const { GET } = await import("./route");
+    const res = await GET(new Request("http://localhost/api/jobs/explain?title=nonexistent"));
+    const body = await res.json();
+
+    expect(body.ok).toBe(true);
+    expect(body.data.matches).toEqual([]);
+  });
+});

--- a/src/app/api/jobs/explain/route.ts
+++ b/src/app/api/jobs/explain/route.ts
@@ -1,0 +1,114 @@
+// src/app/api/jobs/explain/route.ts
+// GET /api/jobs/explain?title=...&company=...
+// Searches raw_jobs directly, with NO mode filter and NO 2000-row cap — the
+// whole point is finding jobs the /pipeline gate-list breakdown would never
+// surface, because they never entered the candidate pool in the first place.
+// Runs each match through the same explainJob() trace used by the dashboard
+// breakdown, so the two paths never disagree about why a job did or didn't
+// make it.
+//
+// Auth: getUser() + resolveUserSettings(), same as /api/dashboard — this is
+// a user checking their own settings against the raw pool, not an admin
+// action, so requireAdmin() doesn't apply here.
+
+import { NextResponse } from "next/server";
+import { getUser, createServerClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { dbErrorResponse } from "@/lib/api-errors";
+import { resolveUserSettings } from "@/lib/settings";
+import { enabledModes } from "@/lib/dashboard-route";
+import { explainJob } from "@/lib/explain";
+import type { JobTraceResult } from "@/lib/explain";
+import { filterJobsWithGeminiVerbose } from "@/lib/gemini";
+import type { RawJob, ResolvedSettings } from "@/lib/types";
+
+// Search-result cap, distinct from MAX_PIPELINE_SAMPLE — this bounds how
+// many jobs a single (possibly broad) title/company search can match, since
+// each match that survives every pre-Gemini gate costs one live Gemini call.
+const MAX_MATCHES = 20;
+// Defensive cap on the raw search input itself — a title/company field has
+// no legitimate reason to be this long, and it keeps an oversized query
+// string from reaching the ilike pattern at all.
+const MAX_QUERY_LENGTH = 100;
+
+/** Traces one job through every gate, fetching a live Gemini decision only
+ *  if the job actually survives to that stage (most searched jobs won't, so
+ *  the common case costs zero extra API calls). Pulled out of GET so the
+ *  request handler reads as "validate → query → trace each match", not a
+ *  single sprawling loop body. */
+async function traceJob(
+  job: RawJob,
+  settings: ResolvedSettings,
+  enabledPipelines: string[],
+  geminiApiKey: string | null | undefined,
+): Promise<JobTraceResult> {
+  let explanation = explainJob(job, settings, null);
+  const reachedGemini = explanation.gates.some((g) => g.gate === "gemini");
+  const needsGemini = !reachedGemini && explanation.stoppedAt === null;
+
+  if (needsGemini && geminiApiKey) {
+    const [decision] = await filterJobsWithGeminiVerbose(geminiApiKey, [job], settings);
+    explanation = explainJob(job, settings, decision ?? null);
+  }
+
+  return {
+    id: job.id,
+    title: job.title,
+    company: job.company,
+    mode: job.mode,
+    pipeline_match: enabledPipelines.includes(job.mode),
+    stopped_at: explanation.stoppedAt,
+    gates: explanation.gates,
+    final_score: explanation.finalScore,
+    gemini_pending: needsGemini && !geminiApiKey,
+  };
+}
+
+export async function GET(request: Request) {
+  const user = await getUser();
+  if (!user) {
+    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const title = (searchParams.get("title")?.trim() ?? "").slice(0, MAX_QUERY_LENGTH);
+  const company = (searchParams.get("company")?.trim() ?? "").slice(0, MAX_QUERY_LENGTH);
+
+  if (!title && !company) {
+    return NextResponse.json(
+      { ok: false, error: "Provide a title or company to search for" },
+      { status: 400 },
+    );
+  }
+
+  const db = createServerClient();
+  // raw_jobs is global, not user-owned — same service-role client as /api/dashboard.
+  const adminDb = createAdminClient();
+
+  const [settings, { data: profile }] = await Promise.all([
+    resolveUserSettings(user.id),
+    db.from("user_profiles").select("gemini_api_key").eq("id", user.id).single(),
+  ]);
+
+  let query = adminDb
+    .from("raw_jobs")
+    .select("*")
+    .order("fetched_at", { ascending: false })
+    .limit(MAX_MATCHES);
+  if (title) query = query.ilike("title", `%${title}%`);
+  if (company) query = query.ilike("company", `%${company}%`);
+
+  const { data: matches, error } = await query;
+  if (error) {
+    return dbErrorResponse("jobs/explain:GET", error);
+  }
+
+  const enabled = enabledModes(settings);
+  const results = await Promise.all(
+    ((matches ?? []) as RawJob[]).map((job) =>
+      traceJob(job, settings, enabled, profile?.gemini_api_key),
+    ),
+  );
+
+  return NextResponse.json({ ok: true, data: { matches: results } });
+}

--- a/src/components/dashboard/DashboardClient.tsx
+++ b/src/components/dashboard/DashboardClient.tsx
@@ -49,8 +49,7 @@ export default function DashboardClient() {
             </span>
             {pipelineLog && (
               <span className="ml-2 text-slate-600">
-                · {pipelineLog.total_fetched} fetched → {pipelineLog.after_gemini_filter} after your
-                Gemini filter
+                · {pipelineLog.total_scraped} scraped → {pipelineLog.on_dashboard} on your dashboard
               </span>
             )}
           </div>

--- a/src/components/pipeline/FunnelView.tsx
+++ b/src/components/pipeline/FunnelView.tsx
@@ -1,52 +1,84 @@
 "use client";
 // src/components/pipeline/FunnelView.tsx
 
-import type { PipelineLog } from "@/lib/types";
+import type { PipelineLog, GateBreakdowns } from "@/lib/types";
+import GateAccordionRow, { type AccordionEntry } from "./GateAccordionRow";
 
 interface Props {
   log: PipelineLog | null;
   loading?: boolean;
 }
 
-interface Stage {
-  key: keyof Omit<PipelineLog, "cached_at">;
+interface FunnelTile {
   label: string;
-  filterLabel: string;
+  description: string;
+  value: number;
   color: string;
 }
 
-const STAGES: Stage[] = [
-  {
-    key: "total_fetched",
-    label: "Fetched",
-    filterLabel: "All raw jobs from ATS sources this cron run",
-    color: "#6366f1",
-  },
-  {
-    key: "after_date_filter",
+type GateKey = keyof GateBreakdowns;
+
+const GATE_META: Record<GateKey, { label: string; description: string }> = {
+  date: {
     label: "Date filter",
-    filterLabel: "Removed jobs older than your configured age limit",
-    color: "#818cf8",
+    description: "Removed jobs older than your configured age limit.",
   },
-  {
-    key: "after_settings_filter",
-    label: "Settings filter",
-    filterLabel: "Removed jobs that failed seniority gate or disabled pipelines",
-    color: "#a78bfa",
+  seniority: {
+    label: "Seniority filter",
+    description: "Removed jobs whose seniority level isn't one you selected.",
   },
-  {
-    key: "after_gemini_filter",
+  excluded_keywords: {
+    label: "Excluded keywords",
+    description: "Removed jobs whose title matched a keyword you excluded.",
+  },
+  required_keywords: {
+    label: "Required keywords",
+    description: "Removed jobs that didn't match any of your required (or expert) skills.",
+  },
+  blacklisted_locations: {
+    label: "Blacklisted locations",
+    description: "Removed jobs matching a location or term you blacklisted.",
+  },
+  skill_match: {
+    label: "Skill match",
+    description: "Removed jobs whose description didn't meaningfully match your skills.",
+  },
+  global_mode: {
+    label: "Global-mode region filter",
+    description: "Removed remote jobs outside your allowed regions (global pipeline only).",
+  },
+  gemini: {
     label: "Your Gemini filter",
-    filterLabel: "Jobs passing your personal AI filter prompt",
-    color: "#c4b5fd",
+    description: "Removed jobs your personal AI filter prompt rejected.",
   },
-  {
-    key: "after_scoring",
+  scoring: {
     label: "Scoring",
-    filterLabel: "Final matches after scoring (jobs scoring 0 are dropped)",
-    color: "#e9d5ff",
+    description: "Removed jobs that scored 0 after skill, recency, and relocation weighting.",
   },
+};
+
+const GATE_ORDER: GateKey[] = [
+  "date",
+  "seniority",
+  "excluded_keywords",
+  "required_keywords",
+  "blacklisted_locations",
+  "skill_match",
+  "global_mode",
+  "gemini",
+  "scoring",
 ];
+
+function toEntries(
+  sample: Array<{ id: string; title: string; company: string; reason: string | null }>,
+): AccordionEntry[] {
+  return sample.map((s) => ({
+    id: s.id,
+    title: s.title,
+    company: s.company,
+    detail: s.reason ?? "—",
+  }));
+}
 
 export default function FunnelView({ log, loading }: Props) {
   if (loading) {
@@ -65,7 +97,27 @@ export default function FunnelView({ log, loading }: Props) {
     );
   }
 
-  const total = log.total_fetched || 1;
+  const tiles: FunnelTile[] = [
+    {
+      label: "Scraped this run",
+      description: "Every job in the raw pool, any pipeline mode.",
+      value: log.total_scraped,
+      color: "#6366f1",
+    },
+    {
+      label: "Matched your pipelines",
+      description: "Jobs whose mode is one of your enabled pipelines.",
+      value: log.matched_pipelines,
+      color: "#a78bfa",
+    },
+    {
+      label: "In candidate window",
+      description: "The pool your gates actually ran against (capped at 2,000).",
+      value: log.candidate_window,
+      color: "#c4b5fd",
+    },
+  ];
+  const maxTile = Math.max(1, ...tiles.map((t) => t.value));
 
   return (
     <div className="p-8">
@@ -74,89 +126,108 @@ export default function FunnelView({ log, loading }: Props) {
         Last built: {new Date(log.cached_at).toLocaleString()}
       </p>
 
-      {/* Funnel nodes */}
-      <div className="flex items-center gap-0 overflow-x-auto pb-4">
-        {STAGES.map((stage, i) => {
-          const count = log[stage.key];
-          const widthPct = Math.max(12, (count / total) * 100);
-          const dropped = i > 0 ? log[STAGES[i - 1].key] - count : 0;
-          const circleSize = `${Math.min(100, Math.max(56, widthPct * 0.8))}px`;
+      {/* Top funnel: scraped → matched pipelines → candidate window */}
+      <div className="flex items-stretch gap-0 overflow-x-auto pb-2">
+        {tiles.map((tile, i) => {
+          const dropped = i > 0 ? tiles[i - 1].value - tile.value : 0;
+          const heightPct = Math.max(15, (tile.value / maxTile) * 100);
 
           return (
-            <div key={stage.key} className="flex shrink-0 items-center">
-              {/* Arrow between nodes */}
+            <div key={tile.label} className="flex shrink-0 items-center">
               {i > 0 && (
-                <div className="flex flex-col items-center px-2">
+                <div className="flex flex-col items-center px-3">
                   <div className="text-xl text-slate-600">→</div>
                   {dropped > 0 && (
-                    <div className="max-w-[60px] text-center text-[10px] leading-tight text-red-500">
-                      −{dropped}
+                    <div className="max-w-[90px] text-center text-[10px] leading-tight text-red-500">
+                      −{dropped.toLocaleString()}
                     </div>
                   )}
                 </div>
               )}
-
-              {/* Node */}
               <div
-                title={stage.filterLabel}
-                className="flex min-w-[100px] flex-col items-center rounded-xl border bg-[#0d0d1a] px-3 py-5 cursor-help"
-                style={{ borderColor: `${stage.color}40` }}
+                title={tile.description}
+                className="flex min-w-[140px] flex-col items-center justify-end gap-2 rounded-xl border bg-[#0d0d1a] px-4 py-5 cursor-help"
+                style={{ borderColor: `${tile.color}40` }}
               >
-                {/* Circle with count */}
                 <div
-                  className="flex items-center justify-center rounded-full border-2 transition-all duration-300 ease-in-out"
-                  style={{
-                    width: circleSize,
-                    height: circleSize,
-                    background: `${stage.color}15`,
-                    borderColor: stage.color,
-                  }}
-                >
-                  <span className="text-lg font-bold" style={{ color: stage.color }}>
-                    {count.toLocaleString()}
-                  </span>
-                </div>
-
-                <div className="mt-2.5 text-center text-xs font-medium text-slate-400">
-                  {stage.label}
-                </div>
-
-                <div className="mt-0.5 text-[10px] text-slate-600">
-                  {Math.round((count / total) * 100)}% of total
-                </div>
+                  className="w-full rounded-md"
+                  style={{ height: `${heightPct}px`, background: `${tile.color}30` }}
+                />
+                <span className="text-lg font-bold" style={{ color: tile.color }}>
+                  {tile.value.toLocaleString()}
+                </span>
+                <span className="text-center text-xs font-medium text-slate-400">{tile.label}</span>
               </div>
             </div>
           );
         })}
       </div>
 
-      {/* Explanatory table */}
+      {/* Ingestion-level losses — same accordion styling as the gate rows below */}
       <div className="mt-8 overflow-hidden rounded-xl border border-[#1e1e30] bg-[#0d0d1a]">
         <div className="border-b border-[#1e1e30] px-5 py-3.5 text-[13px] font-semibold text-slate-500">
-          What was filtered at each stage
+          Before any gate runs
         </div>
-        {STAGES.slice(1).map((stage, i) => {
-          const before = log[STAGES[i].key];
-          const after = log[stage.key];
-          const diff = before - after;
+        <GateAccordionRow
+          label="Wrong pipeline mode"
+          description="Jobs from companies whose pipeline isn't one you've enabled."
+          count={log.wrong_pipeline_mode.count}
+          detailLabel="Mode"
+          note={`Your enabled pipelines: ${log.wrong_pipeline_mode.enabled_pipelines.join(", ") || "none"}`}
+          entries={log.wrong_pipeline_mode.sample.map((s) => ({
+            id: s.id,
+            title: s.title,
+            company: s.company,
+            detail: s.mode,
+          }))}
+        />
+        <GateAccordionRow
+          label="Outside candidate window"
+          description="Jobs that matched your pipelines but were cut by the 2,000-job cap."
+          count={log.outside_candidate_window.count}
+          detailLabel="Fetched"
+          entries={log.outside_candidate_window.sample.map((s) => ({
+            id: s.id,
+            title: s.title,
+            company: s.company,
+            detail: new Date(s.fetched_at).toLocaleString(),
+          }))}
+        />
+      </div>
 
+      {/* Per-gate breakdown, in production order */}
+      <div className="mt-4 overflow-hidden rounded-xl border border-[#1e1e30] bg-[#0d0d1a]">
+        <div className="border-b border-[#1e1e30] px-5 py-3.5 text-[13px] font-semibold text-slate-500">
+          Gate by gate
+        </div>
+        {GATE_ORDER.map((key) => {
+          const gate = log.gates[key];
+          const meta = GATE_META[key];
           return (
-            <div
-              key={stage.key}
-              className="flex items-center border-b border-[#0d0d1a] px-5 py-3 text-[13px]"
-            >
-              <span className="flex-1 text-slate-400">{stage.label}</span>
-              <span className={`font-semibold ${diff > 0 ? "text-red-500" : "text-slate-500"}`}>
-                {diff > 0 ? `−${diff}` : "none"} removed
-              </span>
-            </div>
+            <GateAccordionRow
+              key={key}
+              label={meta.label}
+              description={meta.description}
+              count={gate.count}
+              detailLabel="Reason"
+              entries={toEntries(gate.sample)}
+            />
           );
         })}
       </div>
 
+      {/* Final summary */}
+      <div className="mt-4 flex items-center gap-3 rounded-xl border border-[#1e1e30] bg-[#0d0d1a] px-5 py-4">
+        <span className="text-lg font-bold text-emerald-400">
+          {log.on_dashboard.toLocaleString()}
+        </span>
+        <span className="text-[13px] text-slate-400">jobs on your dashboard</span>
+      </div>
+
       <p className="mt-4 text-xs text-slate-600">
-        Hover any circle for a description of what was filtered. To see more jobs, try widening your
-        age limit, enabling more pipelines, or softening your Gemini prompt in Settings.
+        Hover any tile or row for what it checks. Expand a row to see which jobs it dropped and why.
+        To see more jobs, try widening your age limit, enabling more pipelines, or softening your
+        Gemini prompt in Settings.
       </p>
     </div>
   );

--- a/src/components/pipeline/GateAccordionRow.tsx
+++ b/src/components/pipeline/GateAccordionRow.tsx
@@ -1,0 +1,97 @@
+"use client";
+// src/components/pipeline/GateAccordionRow.tsx
+// One expandable row in the pipeline breakdown: a gate or an ingestion-level
+// loss, its true drop count, and (on expand) a capped, most-recent-first
+// table of which jobs were dropped there and why. Reused by every gate and
+// both ingestion-loss sections in FunnelView — same visual treatment for
+// both, per the confirmed design (no separate styling for ingestion losses).
+
+import { useState } from "react";
+
+export interface AccordionEntry {
+  id: string;
+  title: string;
+  company: string;
+  /** The one variable column: a gate's drop reason, a job's mode, or its fetched time. */
+  detail: string;
+}
+
+interface Props {
+  label: string;
+  description: string;
+  count: number;
+  /** Capped sample of dropped jobs, most-recently-fetched first. */
+  entries: AccordionEntry[];
+  /** Column header for `entry.detail` — "Reason", "Mode", "Fetched", etc. */
+  detailLabel: string;
+  /** Optional section-level context shown above the table (e.g. the user's enabled pipelines). */
+  note?: string;
+}
+
+export default function GateAccordionRow({
+  label,
+  description,
+  count,
+  entries,
+  detailLabel,
+  note,
+}: Props) {
+  const [expanded, setExpanded] = useState(false);
+  const canExpand = count > 0;
+
+  return (
+    <div className="border-b border-[#1e1e30] last:border-b-0">
+      <button
+        type="button"
+        onClick={() => canExpand && setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        disabled={!canExpand}
+        title={description}
+        className="flex w-full items-center gap-3 px-5 py-3.5 text-left cursor-help disabled:cursor-default"
+      >
+        <span
+          className={`text-xs transition-transform ${expanded ? "rotate-90" : ""} ${canExpand ? "text-slate-500" : "text-slate-700"}`}
+        >
+          ▶
+        </span>
+        <span className="flex-1 text-[13px] font-medium text-slate-300">{label}</span>
+        <span
+          className={`text-[13px] font-semibold ${canExpand ? "text-red-500" : "text-slate-600"}`}
+        >
+          {count === 0 ? "none dropped" : `−${count.toLocaleString()}`}
+        </span>
+      </button>
+
+      {expanded && canExpand && (
+        <div className="border-t border-[#1e1e30] bg-[#0a0a14] px-5 py-3">
+          <p className="m-0 mb-3 text-xs text-slate-600">{description}</p>
+          {note && <p className="m-0 mb-3 text-xs text-slate-500">{note}</p>}
+          <table className="w-full border-collapse text-xs">
+            <thead>
+              <tr className="text-left text-slate-600">
+                <th className="pb-2 pr-3 font-medium">Title</th>
+                <th className="pb-2 pr-3 font-medium">Company</th>
+                <th className="pb-2 font-medium">{detailLabel}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map((entry) => (
+                <tr key={entry.id} className="border-t border-[#1e1e30] text-slate-400">
+                  <td className="py-2 pr-3">{entry.title}</td>
+                  <td className="py-2 pr-3 text-slate-500">{entry.company}</td>
+                  <td className="py-2 text-slate-500">{entry.detail}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {count > entries.length && (
+            <p className="m-0 mt-3 text-[11px] text-slate-600">
+              Showing the {entries.length} most recent of {count.toLocaleString()}. Can&apos;t find
+              a specific job here? Use the search below — it checks the full raw pool with no cap.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/pipeline/JobTraceSearch.tsx
+++ b/src/components/pipeline/JobTraceSearch.tsx
@@ -1,0 +1,150 @@
+"use client";
+// src/components/pipeline/JobTraceSearch.tsx
+// "Can't find it in the lists above? Search the full raw pool directly."
+// Bypasses mode filtering and the 2000-row cap entirely — this is the
+// escape hatch for jobs the gate-list breakdown above can never surface,
+// because they never entered the candidate pool in the first place.
+
+import { useState } from "react";
+import type { JobTraceResult } from "@/lib/explain";
+
+const GATE_LABELS: Record<string, string> = {
+  date: "Date filter",
+  seniority: "Seniority filter",
+  excluded_keywords: "Excluded keywords",
+  required_keywords: "Required keywords",
+  blacklisted_locations: "Blacklisted locations",
+  skill_match: "Skill match",
+  global_mode: "Global-mode region filter",
+  gemini: "Your Gemini filter",
+  scoring: "Scoring",
+};
+
+export default function JobTraceSearch() {
+  const [title, setTitle] = useState("");
+  const [company, setCompany] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [results, setResults] = useState<JobTraceResult[] | null>(null);
+
+  async function handleSearch(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim() && !company.trim()) {
+      setError("Enter a title or company to search for.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      if (title.trim()) params.set("title", title.trim());
+      if (company.trim()) params.set("company", company.trim());
+      const res = await fetch(`/api/jobs/explain?${params.toString()}`);
+      const data = await res.json();
+      if (!data.ok) {
+        setError(data.error ?? "Search failed.");
+        setResults(null);
+      } else {
+        setResults(data.data.matches as JobTraceResult[]);
+      }
+    } catch {
+      setError("Search failed — check your connection and try again.");
+      setResults(null);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="mt-4 overflow-hidden rounded-xl border border-[#1e1e30] bg-[#0d0d1a]">
+      <div className="border-b border-[#1e1e30] px-5 py-3.5">
+        <div className="text-[13px] font-semibold text-slate-300">
+          Can&apos;t find it in the lists above?
+        </div>
+        <p className="m-0 mt-1 text-xs text-slate-600">
+          Search the full raw pool directly — no pipeline filter, no 2,000-job cap.
+        </p>
+      </div>
+
+      <form onSubmit={handleSearch} className="flex flex-wrap items-center gap-2 px-5 py-3.5">
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Job title"
+          className="min-w-[160px] flex-1 rounded-lg border border-[#1e1e30] bg-[#0a0a14] px-3 py-2 text-[13px] text-slate-300 placeholder:text-slate-600 focus:border-indigo-400 focus:outline-none"
+        />
+        <input
+          type="text"
+          value={company}
+          onChange={(e) => setCompany(e.target.value)}
+          placeholder="Company"
+          className="min-w-[160px] flex-1 rounded-lg border border-[#1e1e30] bg-[#0a0a14] px-3 py-2 text-[13px] text-slate-300 placeholder:text-slate-600 focus:border-indigo-400 focus:outline-none"
+        />
+        <button
+          type="submit"
+          disabled={loading}
+          className="rounded-lg border border-[#1e1e30] bg-[#1e1e30] px-4 py-2 text-[13px] text-indigo-400 cursor-pointer disabled:cursor-default disabled:opacity-50"
+        >
+          {loading ? "Searching…" : "Search"}
+        </button>
+      </form>
+
+      {error && <p className="mx-5 mb-3 text-xs text-red-500">{error}</p>}
+
+      {results && results.length === 0 && (
+        <p className="mx-5 mb-4 text-xs text-slate-600">
+          No jobs in the raw pool matched that search.
+        </p>
+      )}
+
+      {results && results.length > 0 && (
+        <div className="border-t border-[#1e1e30]">
+          {results.map((job) => (
+            <div key={job.id} className="border-b border-[#1e1e30] px-5 py-3.5 last:border-b-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-[13px] font-medium text-slate-300">{job.title}</span>
+                <span className="text-[13px] text-slate-500">· {job.company}</span>
+                <span
+                  className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${
+                    job.pipeline_match
+                      ? "bg-emerald-400/10 text-emerald-400"
+                      : "bg-red-500/10 text-red-500"
+                  }`}
+                >
+                  {job.mode} pipeline {job.pipeline_match ? "· enabled" : "· not enabled"}
+                </span>
+              </div>
+
+              <div className="mt-2 text-xs text-slate-500">
+                {job.stopped_at ? (
+                  <>
+                    Stopped at{" "}
+                    <span className="font-medium text-red-500">
+                      {GATE_LABELS[job.stopped_at] ?? job.stopped_at}
+                    </span>
+                    : {job.gates.find((g) => g.gate === job.stopped_at)?.reason}
+                  </>
+                ) : job.gemini_pending ? (
+                  <>Passed every gate so far — add a Gemini API key in Settings to check further.</>
+                ) : (
+                  <>
+                    Passed every gate — on your dashboard with a score of{" "}
+                    <span className="font-medium text-emerald-400">{job.final_score}</span>.
+                  </>
+                )}
+              </div>
+
+              {!job.pipeline_match && (
+                <p className="m-0 mt-1 text-[11px] text-slate-600">
+                  This job never entered your candidate pool — its mode isn&apos;t one of your
+                  enabled pipelines, regardless of what the gates above show.
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/__tests__/dashboard-route.test.ts
+++ b/src/lib/__tests__/dashboard-route.test.ts
@@ -8,11 +8,11 @@ import type { RawJob, ResolvedSettings } from "../types";
 
 // ── Mock Gemini (network call) ─────────────────────────────────
 vi.mock("../gemini", () => ({
-  filterJobsWithGemini: vi.fn(),
+  filterJobsWithGeminiVerbose: vi.fn(),
 }));
 
-import { filterJobsWithGemini } from "../gemini";
-const mockGemini = filterJobsWithGemini as ReturnType<typeof vi.fn>;
+import { filterJobsWithGeminiVerbose } from "../gemini";
+const mockGemini = filterJobsWithGeminiVerbose as ReturnType<typeof vi.fn>;
 
 import { buildFeed, enabledModes } from "../dashboard-route";
 
@@ -70,6 +70,11 @@ function makeSettings(overrides: Partial<ResolvedSettings> = {}): ResolvedSettin
   } as ResolvedSettings;
 }
 
+/** A passing verbose Gemini decision for the given job(s). */
+function passingDecision(job: RawJob) {
+  return { id: job.id, pass: true, reason: null, reviewed: true, quotaExhausted: false };
+}
+
 // ── enabledModes ──────────────────────────────────────────────
 
 describe("enabledModes", () => {
@@ -104,12 +109,13 @@ describe("buildFeed", () => {
 
   it("returns an empty feed when no raw jobs are provided", async () => {
     mockGemini.mockResolvedValue([]);
-    const { finalJobs, pipelineLog } = await buildFeed([], settings, "key-abc");
+    const { finalJobs, gateLog } = await buildFeed([], settings, "key-abc");
 
     expect(finalJobs).toEqual([]);
-    expect(pipelineLog.total_fetched).toBe(0);
-    expect(pipelineLog.after_gemini_filter).toBe(0);
-    expect(pipelineLog.after_scoring).toBe(0);
+    expect(gateLog.candidate_window).toBe(0);
+    expect(gateLog.on_dashboard).toBe(0);
+    expect(gateLog.gates.gemini.count).toBe(0);
+    expect(gateLog.gates.scoring.count).toBe(0);
   });
 
   it("skips Gemini and marks jobs not-reviewed when no API key is given", async () => {
@@ -123,18 +129,9 @@ describe("buildFeed", () => {
     expect(finalJobs[0].gemini_reviewed).toBe(false);
   });
 
-  it("calls Gemini when an API key is supplied", async () => {
+  it("calls the verbose Gemini variant when an API key is supplied", async () => {
     const job = makeJob({ title: "Senior React Engineer" });
-    // Gemini marks the job as passing
-    mockGemini.mockResolvedValue([
-      {
-        ...job,
-        gemini_pass: true,
-        gemini_reason: null,
-        gemini_reviewed: true,
-        gemini_quota_exhausted: false,
-      },
-    ]);
+    mockGemini.mockResolvedValue([passingDecision(job)]);
 
     const { finalJobs } = await buildFeed([job], settings, "user-api-key");
 
@@ -143,107 +140,109 @@ describe("buildFeed", () => {
     expect(finalJobs[0].gemini_reviewed).toBe(true);
   });
 
-  it("filters out jobs older than job_age_days", async () => {
+  it("filters out jobs older than job_age_days, attributing the drop to the date gate", async () => {
     const oldDate = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString(); // 60 days ago
     const oldJob = makeJob({ posted_at: oldDate, fetched_at: oldDate, date_unknown: false });
 
-    const { pipelineLog } = await buildFeed([oldJob], makeSettings({ job_age_days: 30 }), null);
+    const { gateLog } = await buildFeed([oldJob], makeSettings({ job_age_days: 30 }), null);
 
-    expect(pipelineLog.after_date_filter).toBe(0);
-    expect(pipelineLog.after_scoring).toBe(0);
+    expect(gateLog.gates.date.count).toBe(1);
+    expect(gateLog.gates.date.sample[0]).toMatchObject({ id: oldJob.id, title: oldJob.title });
+    expect(gateLog.on_dashboard).toBe(0);
   });
 
-  it("excludes jobs whose titles contain an excluded keyword", async () => {
-    const job = makeJob({ title: "Junior React Developer" });
-    const settingsWithExclude = makeSettings({ excluded_keywords: ["Junior"] });
+  it("excludes jobs whose titles contain an excluded keyword, attributing the drop to that gate", async () => {
+    const job = makeJob({ title: "Backend Engineer" });
+    const settingsWithExclude = makeSettings({ excluded_keywords: ["Backend"] });
 
-    const { pipelineLog } = await buildFeed([job], settingsWithExclude, null);
+    const { gateLog } = await buildFeed([job], settingsWithExclude, null);
 
-    expect(pipelineLog.after_settings_filter).toBe(0);
+    expect(gateLog.gates.excluded_keywords.count).toBe(1);
+    expect(gateLog.gates.excluded_keywords.sample[0].reason).toContain("Backend");
+    // Never reaches later gates.
+    expect(gateLog.gates.seniority.count).toBe(0);
   });
 
-  it("pipeline log counts are consistent with final job list length", async () => {
+  it("gate breakdown counts are consistent with the final job list length", async () => {
     const job = makeJob({ title: "Senior React Engineer" });
-    mockGemini.mockResolvedValue([
-      {
-        ...job,
-        gemini_pass: true,
-        gemini_reason: null,
-        gemini_reviewed: true,
-        gemini_quota_exhausted: false,
-      },
-    ]);
+    mockGemini.mockResolvedValue([passingDecision(job)]);
 
-    const { finalJobs, pipelineLog } = await buildFeed([job], settings, "key");
+    const { finalJobs, gateLog } = await buildFeed([job], settings, "key");
 
-    expect(pipelineLog.total_fetched).toBe(1);
-    expect(pipelineLog.after_date_filter).toBe(1);
-    expect(pipelineLog.after_settings_filter).toBe(1);
-    expect(pipelineLog.after_gemini_filter).toBe(1);
-    expect(pipelineLog.after_scoring).toBe(finalJobs.length);
+    expect(gateLog.candidate_window).toBe(1);
+    expect(gateLog.gates.date.count).toBe(0);
+    expect(gateLog.gates.gemini.count).toBe(0);
+    expect(gateLog.on_dashboard).toBe(finalJobs.length);
   });
 
-  it("drops jobs with total_score ≤ 0 from the final feed", async () => {
-    // A job that is both very old (recency_score = 0) and has no skill matches
-    // (skill_match_score = 0) will have total_score = 0 and must be dropped.
-    const oldDate = new Date(Date.now() - 120 * 24 * 60 * 60 * 1000).toISOString(); // 120 days ago
-    const staleZeroSkillJob = makeJob({
-      title: "COBOL Programmer",
-      description: "Needs COBOL experience only",
-      posted_at: oldDate,
-      fetched_at: oldDate,
-      date_unknown: false,
+  it("drops jobs with total_score ≤ 0 from the final feed, attributing it to the scoring gate (not Gemini)", async () => {
+    // Zeroed scoring weights guarantee total_score = 0 regardless of how
+    // well the job otherwise matches — deliberately not using a "zero
+    // skill match" fixture here, since skill_match_score = 0 is
+    // incompatible with passing the skill_match GATE (both derive from the
+    // same underlying keyword match), so that scenario can't occur for a
+    // job that reaches scoring at all.
+    const matchingJob = makeJob({
+      title: "Senior React Engineer",
+      description: "We need React expertise",
     });
-    // job_age_days is 365 so the job passes the date gate, but its score will be 0
-    const settingsWideAge = makeSettings({
-      job_age_days: 365,
-      required_keywords: [],
-      expert_skills: ["React"], // no match against COBOL description
+    const settingsZeroWeight = makeSettings({
+      scoring_weights: { skill: 0, recency: 0, relocation: 0 },
     });
-    mockGemini.mockResolvedValue([
-      {
-        ...staleZeroSkillJob,
-        gemini_pass: true,
-        gemini_reason: null,
-        gemini_reviewed: true,
-        gemini_quota_exhausted: false,
-      },
-    ]);
+    mockGemini.mockResolvedValue([passingDecision(matchingJob)]);
 
-    const { finalJobs, pipelineLog } = await buildFeed([staleZeroSkillJob], settingsWideAge, "key");
+    const { finalJobs, gateLog } = await buildFeed([matchingJob], settingsZeroWeight, "key");
 
-    // Both skill_match_score and recency_score are 0 → total_score = 0 → dropped
+    // Zero-weighted scoring → total_score = 0 → dropped
     expect(finalJobs).toHaveLength(0);
     // The job DID pass Gemini -- it's the scoring stage that drops it. If these
     // two numbers were still the same field (the old `after_gemini` bug), this
     // job's rejection would get silently attributed to "failed your Gemini
     // filter" when it never did.
-    expect(pipelineLog.after_gemini_filter).toBe(1);
-    expect(pipelineLog.after_scoring).toBe(0);
+    expect(gateLog.gates.gemini.count).toBe(0);
+    expect(gateLog.gates.scoring.count).toBe(1);
+    expect(gateLog.gates.scoring.sample[0].reason).toContain("final score");
+    expect(gateLog.on_dashboard).toBe(0);
   });
 
-  it("keeps a recent job with zero skill match (non-zero recency keeps total_score > 0)", async () => {
-    const recentZeroSkillJob = makeJob({
-      title: "COBOL Programmer",
-      description: "Needs COBOL experience only",
+  it("a fresh job survives even when scoring is weighted entirely toward recency", async () => {
+    // Renamed from the old "zero skill match" framing: a job can't have
+    // skill_match_score = 0 while also clearing the skill_match GATE (see
+    // the note above), so this instead verifies the same underlying point —
+    // total_score isn't purely a function of skill match — by zeroing the
+    // skill weight directly rather than trying to zero the score itself.
+    const recentJob = makeJob({
+      title: "Senior React Engineer",
+      description: "We need React expertise",
     });
-    const settingsNoMatch = makeSettings({ required_keywords: [], expert_skills: ["React"] });
-    mockGemini.mockResolvedValue([
-      {
-        ...recentZeroSkillJob,
-        gemini_pass: true,
-        gemini_reason: null,
-        gemini_reviewed: true,
-        gemini_quota_exhausted: false,
-      },
-    ]);
+    const settingsRecencyOnly = makeSettings({
+      scoring_weights: { skill: 0, recency: 1, relocation: 0 },
+    });
+    mockGemini.mockResolvedValue([passingDecision(recentJob)]);
 
-    const { finalJobs } = await buildFeed([recentZeroSkillJob], settingsNoMatch, "key");
+    const { finalJobs } = await buildFeed([recentJob], settingsRecencyOnly, "key");
 
-    // skill_match_score = 0 but recency_score is high (job is from today)
-    // → total_score > 0 → job survives
     expect(finalJobs).toHaveLength(1);
     expect(finalJobs[0].recency_score).toBeGreaterThan(0);
     expect(finalJobs[0].total_score).toBeGreaterThan(0);
+  });
+
+  it("skips the global_mode gate entirely for local-mode jobs", async () => {
+    const job = makeJob({ mode: "local", title: "Frontend Engineer (US Only)" });
+    mockGemini.mockResolvedValue([passingDecision(job)]);
+
+    const { gateLog } = await buildFeed([job], settings, "key");
+
+    expect(gateLog.gates.global_mode.count).toBe(0);
+  });
+
+  it("caps each gate's sample at MAX_PIPELINE_SAMPLE while keeping the true count uncapped", async () => {
+    const jobs = Array.from({ length: 60 }, (_, i) =>
+      makeJob({ id: `job-${i}`, title: "Junior Developer" }),
+    );
+    const { gateLog } = await buildFeed([...jobs], settings, null);
+
+    expect(gateLog.gates.seniority.count).toBe(60);
+    expect(gateLog.gates.seniority.sample).toHaveLength(50);
   });
 });

--- a/src/lib/__tests__/explain.test.ts
+++ b/src/lib/__tests__/explain.test.ts
@@ -1,0 +1,210 @@
+// src/lib/__tests__/explain.test.ts
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { explainJob } from "../explain";
+import type { RawJob, ResolvedSettings } from "../types";
+
+const NOW = new Date("2025-06-01T12:00:00Z").getTime();
+
+function makeJob(overrides: Partial<RawJob> = {}): RawJob {
+  return {
+    id: "test-job-1",
+    title: "Senior Frontend Engineer",
+    company: "Acme Corp",
+    location: "London, UK",
+    country: "GB",
+    country_flag: "🇬🇧",
+    url: "https://jobs.example.com/1",
+    description: "We need a React and TypeScript expert",
+    posted_at: new Date(NOW - 86_400_000).toISOString(),
+    fetched_at: new Date(NOW).toISOString(),
+    date_unknown: false,
+    is_remote: false,
+    salary: null,
+    mode: "local",
+    visa_sponsorship: false,
+    source_name: "Acme",
+    ats_type: "greenhouse",
+    created_at: new Date(NOW).toISOString(),
+    ...overrides,
+  };
+}
+
+const SETTINGS: ResolvedSettings = {
+  expert_skills: ["React", "TypeScript"],
+  secondary_skills: ["GraphQL"],
+  bonus_skills: [],
+  job_age_days: 7,
+  pipeline_local: true,
+  pipeline_global: true,
+  junior_keywords: ["junior"],
+  mid_keywords: ["mid-level"],
+  senior_keywords: ["senior"],
+  staff_keywords: ["staff"],
+  seniority_levels: ["senior", "staff"],
+  gemini_filter_prompt: "",
+  scoring_weights: { skill: 0.6, recency: 0.3, relocation: 0.1 },
+  score_denominator: 18,
+  excluded_keywords: ["sales"],
+  blacklisted_locations: ["israel"],
+  required_keywords: [],
+  global_mode_blocked_regions: ["us only"],
+  global_mode_allowed_locations: ["remote", "worldwide"],
+  email_alerts_enabled: true,
+  salary_reminder_enabled: true,
+};
+
+const PASSING_GEMINI = { pass: true, reason: "Good fit", reviewed: true };
+
+describe("explainJob — short-circuit ordering", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("stops at the date gate and doesn't evaluate later gates", () => {
+    const job = makeJob({ posted_at: new Date(NOW - 30 * 86_400_000).toISOString() });
+    const result = explainJob(job, SETTINGS, null);
+
+    expect(result.stoppedAt).toBe("date");
+    expect(result.gates).toHaveLength(1);
+    expect(result.gates[0].gate).toBe("date");
+    expect(result.gates[0].pass).toBe(false);
+    expect(result.finalScore).toBeNull();
+  });
+
+  it("stops at seniority when date passes but seniority fails", () => {
+    const job = makeJob({ title: "Junior Frontend Developer" });
+    const result = explainJob(job, SETTINGS, null);
+
+    expect(result.stoppedAt).toBe("seniority");
+    expect(result.gates.map((g) => g.gate)).toEqual(["date", "seniority"]);
+  });
+
+  it("stops at excluded_keywords", () => {
+    const job = makeJob({ title: "Senior Sales Engineer" });
+    const result = explainJob(job, SETTINGS, null);
+
+    expect(result.stoppedAt).toBe("excluded_keywords");
+    expect(result.gates.map((g) => g.gate)).toEqual(["date", "seniority", "excluded_keywords"]);
+  });
+
+  it("stops at blacklisted_locations", () => {
+    const job = makeJob({ location: "Tel Aviv, Israel" });
+    const result = explainJob(job, SETTINGS, null);
+
+    expect(result.stoppedAt).toBe("blacklisted_locations");
+  });
+
+  it("stops at skill_match", () => {
+    const job = makeJob({ description: "We use Angular and Svelte" });
+    const settings = {
+      ...SETTINGS,
+      required_keywords: ["angular"],
+      expert_skills: ["Vue"],
+      secondary_skills: [],
+    };
+    const result = explainJob(job, settings, null);
+
+    expect(result.stoppedAt).toBe("skill_match");
+  });
+
+  it("skips global_mode entirely for a local-mode job", () => {
+    const job = makeJob({ mode: "local", title: "Frontend Engineer (US Only)" });
+    const result = explainJob(job, SETTINGS, PASSING_GEMINI);
+
+    expect(result.gates.map((g) => g.gate)).not.toContain("global_mode");
+  });
+
+  it("evaluates global_mode for a global-mode job and stops there on failure", () => {
+    const job = makeJob({ mode: "global", title: "Frontend Engineer (US Only)" });
+    const result = explainJob(job, SETTINGS, null);
+
+    expect(result.stoppedAt).toBe("global_mode");
+    expect(result.gates.map((g) => g.gate)).toEqual([
+      "date",
+      "seniority",
+      "excluded_keywords",
+      "required_keywords",
+      "blacklisted_locations",
+      "skill_match",
+      "global_mode",
+    ]);
+  });
+});
+
+describe("explainJob — Gemini stage", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns stoppedAt: null (incomplete trace) when every gate passes but no Gemini result was supplied", () => {
+    const job = makeJob();
+    const result = explainJob(job, SETTINGS, null);
+
+    expect(result.stoppedAt).toBeNull();
+    expect(result.gates.map((g) => g.gate)).not.toContain("gemini");
+    expect(result.finalScore).toBeNull();
+  });
+
+  it("stops at gemini when the supplied decision failed", () => {
+    const job = makeJob();
+    const result = explainJob(job, SETTINGS, {
+      pass: false,
+      reason: "Not a fit per your prompt",
+      reviewed: true,
+    });
+
+    expect(result.stoppedAt).toBe("gemini");
+    const geminiOutcome = result.gates.find((g) => g.gate === "gemini");
+    expect(geminiOutcome).toEqual({
+      gate: "gemini",
+      pass: false,
+      reason: "Not a fit per your prompt",
+    });
+  });
+
+  it("reaches scoring and reports finalScore when Gemini passes and the job scores above 0", () => {
+    const job = makeJob({ description: "We need React and TypeScript expert" });
+    const result = explainJob(job, SETTINGS, PASSING_GEMINI);
+
+    expect(result.stoppedAt).toBeNull();
+    expect(result.gates.map((g) => g.gate)).toContain("scoring");
+    expect(result.finalScore).not.toBeNull();
+    expect(result.finalScore).toBeGreaterThan(0);
+  });
+
+  it("stops at scoring when the job passes every gate but scores 0 or below", () => {
+    // No skill match content at all beyond the boilerplate-window bar would
+    // normally fail skill_match first — force a pass-everything-but-score-0
+    // path via zeroed scoring weights instead.
+    const job = makeJob();
+    const settings = {
+      ...SETTINGS,
+      scoring_weights: { skill: 0, recency: 0, relocation: 0 },
+    };
+    const result = explainJob(job, settings, PASSING_GEMINI);
+
+    expect(result.stoppedAt).toBe("scoring");
+    expect(result.finalScore).toBe(0);
+  });
+});
+
+describe("explainJob — reason is null on every passing gate", () => {
+  it("never attaches a reason to a gate that passed", () => {
+    const job = makeJob();
+    const result = explainJob(job, SETTINGS, PASSING_GEMINI);
+
+    for (const gate of result.gates) {
+      if (gate.pass) {
+        expect(gate.reason).toBeNull();
+      }
+    }
+  });
+});

--- a/src/lib/__tests__/gemini.test.ts
+++ b/src/lib/__tests__/gemini.test.ts
@@ -3,7 +3,11 @@
 // jobs by positional index, not by echoing the job ID.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { filterJobsWithGemini, generateApplicationStrategy } from "../gemini";
+import {
+  filterJobsWithGemini,
+  filterJobsWithGeminiVerbose,
+  generateApplicationStrategy,
+} from "../gemini";
 import type { RawJob } from "../types";
 
 const { generateContentMock } = vi.hoisted(() => ({ generateContentMock: vi.fn() }));
@@ -163,6 +167,72 @@ describe("filterJobsWithGemini — index-based matching", () => {
     expect(result[0].gemini_pass).toBe(true);
     expect(result[0].gemini_reason).toBeNull();
     expect(result[0].gemini_reviewed).toBe(false);
+  });
+});
+
+describe("filterJobsWithGeminiVerbose — same batch calls, keeps failures", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    generateContentMock.mockReset();
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it("returns every job, tagged pass or fail, instead of dropping failures", async () => {
+    const jobs = [
+      makeJob({ id: "visa_gh_acme_1", title: "Frontend Engineer" }),
+      makeJob({ id: "visa_lever_globex_2", title: "Sales Manager" }),
+    ];
+    generateContentMock.mockResolvedValue({
+      text: JSON.stringify([
+        { idx: 0, pass: true, reason: "Strong React match" },
+        { idx: 1, pass: false, reason: "Not an engineering role" },
+      ]),
+    });
+
+    const result = await filterJobsWithGeminiVerbose("key", jobs, settings);
+
+    expect(result).toHaveLength(2);
+    const passing = result.find((r) => r.id === "visa_gh_acme_1");
+    const failing = result.find((r) => r.id === "visa_lever_globex_2");
+    expect(passing).toEqual({
+      id: "visa_gh_acme_1",
+      pass: true,
+      reason: "Strong React match",
+      reviewed: true,
+      quotaExhausted: false,
+    });
+    expect(failing).toEqual({
+      id: "visa_lever_globex_2",
+      pass: false,
+      reason: "Not an engineering role",
+      reviewed: true,
+      quotaExhausted: false,
+    });
+  });
+
+  it("only calls the model once per batch — same call count as filterJobsWithGemini", async () => {
+    const jobs = [makeJob({ id: "a" }), makeJob({ id: "b" })];
+    generateContentMock.mockResolvedValue({
+      text: JSON.stringify([
+        { idx: 0, pass: true, reason: "ok" },
+        { idx: 1, pass: false, reason: "no" },
+      ]),
+    });
+
+    await filterJobsWithGeminiVerbose("key", jobs, settings);
+
+    expect(generateContentMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an empty array without calling the model when apiKey or jobs is empty", async () => {
+    expect(await filterJobsWithGeminiVerbose("", [makeJob()], settings)).toEqual([]);
+    expect(await filterJobsWithGeminiVerbose("key", [], settings)).toEqual([]);
+    expect(generateContentMock).not.toHaveBeenCalled();
   });
 });
 

--- a/src/lib/__tests__/scoring.test.ts
+++ b/src/lib/__tests__/scoring.test.ts
@@ -15,6 +15,13 @@ import {
   passesGlobalModeGate,
   getMatchedLevels,
   getDisplaySeniorityBadge,
+  explainDateGate,
+  explainSeniorityGate,
+  explainExcludedKeywordsGate,
+  explainRequiredKeywordsGate,
+  explainBlacklistedLocationsGate,
+  explainSkillMatchGate,
+  explainGlobalModeGate,
 } from "../scoring";
 import type { RawJob, ResolvedSettings } from "../types";
 
@@ -303,6 +310,26 @@ describe("passesSeniorityGate", () => {
   });
 });
 
+describe("explainSeniorityGate", () => {
+  it("returns pass:true, reason:null for an unlabelled job", () => {
+    const job = makeJob({ title: "Frontend Engineer" });
+    expect(explainSeniorityGate(job, DEFAULT_SETTINGS)).toEqual({ pass: true, reason: null });
+  });
+
+  it("returns pass:true, reason:null when a matched level is enabled", () => {
+    const job = makeJob({ title: "Senior React Developer" });
+    expect(explainSeniorityGate(job, DEFAULT_SETTINGS)).toEqual({ pass: true, reason: null });
+  });
+
+  it("returns pass:false with matched/enabled levels in the reason on failure", () => {
+    const job = makeJob({ title: "Junior Frontend Developer" });
+    const result = explainSeniorityGate(job, DEFAULT_SETTINGS);
+    expect(result.pass).toBe(false);
+    expect(result.reason).toContain("junior");
+    expect(result.reason).toContain("senior");
+  });
+});
+
 // ── passesDateGate ───────────────────────────────────────────
 // Date gate uses fetched_at as fallback when date_unknown = true.
 
@@ -343,6 +370,36 @@ describe("passesDateGate", () => {
       date_unknown: true,
     });
     expect(passesDateGate(job, 7)).toBe(false);
+  });
+});
+
+describe("explainDateGate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns pass:true, reason:null within the window", () => {
+    const job = makeJob({ posted_at: new Date(NOW - 3 * 86_400_000).toISOString() });
+    expect(explainDateGate(job, 7)).toEqual({ pass: true, reason: null });
+  });
+
+  it("returns pass:false with age and limit in the reason when too old", () => {
+    const job = makeJob({ posted_at: new Date(NOW - 10 * 86_400_000).toISOString() });
+    const result = explainDateGate(job, 7);
+    expect(result.pass).toBe(false);
+    expect(result.reason).toContain("10d");
+    expect(result.reason).toContain("7d");
+  });
+
+  it("returns pass:false with an unparseable-date reason for a bad date string", () => {
+    const job = makeJob({ posted_at: "not-a-date" });
+    const result = explainDateGate(job, 7);
+    expect(result.pass).toBe(false);
+    expect(result.reason).toContain("could not be parsed");
   });
 });
 
@@ -618,5 +675,106 @@ describe("passesGlobalModeGate", () => {
   it("uses word boundaries — 'us only' should not match 'usability'", () => {
     const job = makeJob({ title: "Developer", description: "Build great usability into products" });
     expect(passesGlobalModeGate(job, DEFAULT_SETTINGS)).toBe(true);
+  });
+});
+
+// ── Explain variants ──────────────────────────────────────────
+// These power the pipeline breakdown / job-trace search (explain.ts).
+// Each must: match its passesXGate sibling's pass/fail, and return
+// reason: null on pass (nothing downstream renders a reason for a survivor).
+
+describe("explainExcludedKeywordsGate", () => {
+  it("pass:true, reason:null when no excluded_keywords are set", () => {
+    const job = makeJob({ title: "Senior React Engineer" });
+    expect(explainExcludedKeywordsGate(job, DEFAULT_SETTINGS)).toEqual({
+      pass: true,
+      reason: null,
+    });
+  });
+
+  it("names the matched excluded keyword on failure", () => {
+    const job = makeJob({ title: "Senior Sales Engineer" });
+    const settings = { ...DEFAULT_SETTINGS, excluded_keywords: ["sales"] };
+    const result = explainExcludedKeywordsGate(job, settings);
+    expect(result.pass).toBe(false);
+    expect(result.reason).toContain("sales");
+  });
+});
+
+describe("explainRequiredKeywordsGate", () => {
+  it("pass:true, reason:null when expert_skills fallback matches", () => {
+    const job = makeJob({ description: "We need React and TypeScript" });
+    expect(explainRequiredKeywordsGate(job, DEFAULT_SETTINGS)).toEqual({
+      pass: true,
+      reason: null,
+    });
+  });
+
+  it("lists the checked keyword set on failure", () => {
+    const job = makeJob({ title: "Backend Engineer", description: "Go and Python" });
+    const settings = { ...DEFAULT_SETTINGS, required_keywords: ["Rust"] };
+    const result = explainRequiredKeywordsGate(job, settings);
+    expect(result.pass).toBe(false);
+    expect(result.reason).toContain("Rust");
+  });
+});
+
+describe("explainBlacklistedLocationsGate", () => {
+  it("pass:true, reason:null when no blacklisted_locations are set", () => {
+    const job = makeJob({ location: "London, UK" });
+    expect(explainBlacklistedLocationsGate(job, DEFAULT_SETTINGS)).toEqual({
+      pass: true,
+      reason: null,
+    });
+  });
+
+  it("names the matched blacklisted term on failure", () => {
+    const job = makeJob({ location: "San Francisco, US" });
+    const settings = { ...DEFAULT_SETTINGS, blacklisted_locations: ["US"] };
+    const result = explainBlacklistedLocationsGate(job, settings);
+    expect(result.pass).toBe(false);
+    expect(result.reason).toContain("US");
+  });
+});
+
+describe("explainSkillMatchGate", () => {
+  it("pass:true, reason:null when a skill matches", () => {
+    const job = makeJob({ description: "We use React heavily" });
+    expect(explainSkillMatchGate(job, DEFAULT_SETTINGS)).toEqual({ pass: true, reason: null });
+  });
+
+  it("returns a flat reason on failure (no single matched term to report)", () => {
+    const job = makeJob({ description: "We use Angular and Svelte" });
+    const settings = { ...DEFAULT_SETTINGS, expert_skills: ["Vue"], secondary_skills: [] };
+    const result = explainSkillMatchGate(job, settings);
+    expect(result.pass).toBe(false);
+    expect(result.reason).toBe("no expert or secondary skill found in the job description");
+  });
+});
+
+describe("explainGlobalModeGate", () => {
+  it("pass:true, reason:null with no blocked or allowed keywords", () => {
+    const job = makeJob({
+      title: "Frontend Engineer",
+      description: "React + TypeScript",
+      location: "Porto, Portugal",
+    });
+    expect(explainGlobalModeGate(job, DEFAULT_SETTINGS)).toEqual({ pass: true, reason: null });
+  });
+
+  it("names the matched blocked region on failure", () => {
+    const job = makeJob({ title: "Frontend Engineer (US Only)", location: "New York" });
+    const result = explainGlobalModeGate(job, DEFAULT_SETTINGS);
+    expect(result.pass).toBe(false);
+    expect(result.reason).toContain("us only");
+  });
+
+  it("pass:true, reason:null when an allowed location short-circuits a blocked match", () => {
+    const job = makeJob({
+      title: "Developer",
+      description: "This is a worldwide remote role",
+      location: "US Only",
+    });
+    expect(explainGlobalModeGate(job, DEFAULT_SETTINGS)).toEqual({ pass: true, reason: null });
   });
 });

--- a/src/lib/dashboard-route.ts
+++ b/src/lib/dashboard-route.ts
@@ -3,55 +3,148 @@
 // No Next.js Request/Response, no Supabase calls — only transforms.
 // Kept separate so it's unit-testable without mocking the route layer.
 
-import { filterJobsWithGemini } from "@/lib/gemini";
+import { filterJobsWithGeminiVerbose } from "@/lib/gemini";
 import {
   scoreJob,
   mergeJobs,
-  passesDateGate,
-  passesSettingsGate,
-  passesGlobalModeGate,
+  explainDateGate,
+  explainSeniorityGate,
+  explainExcludedKeywordsGate,
+  explainRequiredKeywordsGate,
+  explainBlacklistedLocationsGate,
+  explainSkillMatchGate,
+  explainGlobalModeGate,
 } from "@/lib/scoring";
-import type { RawJob, ScoredJob, PipelineLog, ResolvedSettings } from "@/lib/types";
+import { MAX_PIPELINE_SAMPLE } from "@/lib/types";
+import type {
+  RawJob,
+  ScoredJob,
+  GateLog,
+  GateBreakdown,
+  DroppedJobEntry,
+  ResolvedSettings,
+} from "@/lib/types";
 
 export type FeedResult = {
   finalJobs: ScoredJob[];
-  pipelineLog: PipelineLog;
+  gateLog: GateLog;
 };
 
-/** Applies every pipeline stage (date → settings → global-mode → Gemini → score → merge)
- *  to the supplied raw job pool and returns the final job list with its pipeline log. */
+function toEntry(job: RawJob, reason: string | null): DroppedJobEntry {
+  return { id: job.id, title: job.title, company: job.company, reason };
+}
+
+// rawJobs (and therefore every survivors[] derived from it) arrives sorted
+// fetched_at descending from the SQL query in the route handler — filtering
+// preserves that order, so slicing the front of a dropped list already
+// gives "most recently fetched N", no extra sort needed here.
+function capSample(entries: DroppedJobEntry[]): DroppedJobEntry[] {
+  return entries.slice(0, MAX_PIPELINE_SAMPLE);
+}
+
+/** Runs one gate's explain function over `pool`, splitting it into jobs that
+ *  passed (carried into the next stage) and a capped/counted breakdown of
+ *  what was dropped and why. One shared shape for every gate — including
+ *  gates like global_mode where `explain` may be a passthrough for jobs the
+ *  gate doesn't apply to. */
+function runGate(
+  pool: RawJob[],
+  explain: (job: RawJob) => { pass: boolean; reason: string | null },
+): { survivors: RawJob[]; breakdown: GateBreakdown } {
+  const survivors: RawJob[] = [];
+  const dropped: DroppedJobEntry[] = [];
+  for (const job of pool) {
+    const { pass, reason } = explain(job);
+    if (pass) {
+      survivors.push(job);
+    } else {
+      dropped.push(toEntry(job, reason));
+    }
+  }
+  return { survivors, breakdown: { count: dropped.length, sample: capSample(dropped) } };
+}
+
+/** Applies every pipeline stage (date → seniority → excluded keywords →
+ *  required keywords → blacklisted locations → skill match → global-mode →
+ *  Gemini → score → merge) to the supplied raw job pool and returns the
+ *  final job list with a full per-gate breakdown of what was dropped and why.
+ *
+ *  Ingestion-level losses (wrong pipeline mode, outside the 2000-row candidate
+ *  window) happen before this function is ever called — they require DB
+ *  queries this pure function has no client for. The route handler computes
+ *  those separately and merges them into the final PipelineLog. */
 export async function buildFeed(
   rawJobs: RawJob[],
   settings: ResolvedSettings,
   geminiApiKey: string | null | undefined,
 ): Promise<FeedResult> {
-  const totalFetched = rawJobs.length;
-
-  // Stage 1: Date filter
-  const afterDateFilter = rawJobs.filter((j) => passesDateGate(j, settings.job_age_days));
-
-  // Stage 2: Settings filter (seniority + tech stack + regex gates)
-  const afterSettingsFilter = afterDateFilter.filter((j) => passesSettingsGate(j, settings));
-
-  // Stage 3: Global-mode timezone/region filter (only for "global" pipeline jobs)
-  const afterGlobalModeFilter = afterSettingsFilter.filter((j) =>
-    j.mode === "global" ? passesGlobalModeGate(j, settings) : true,
+  const dateResult = runGate(rawJobs, (j) => explainDateGate(j, settings.job_age_days));
+  const seniorityResult = runGate(dateResult.survivors, (j) => explainSeniorityGate(j, settings));
+  const excludedResult = runGate(seniorityResult.survivors, (j) =>
+    explainExcludedKeywordsGate(j, settings),
+  );
+  const requiredResult = runGate(excludedResult.survivors, (j) =>
+    explainRequiredKeywordsGate(j, settings),
+  );
+  const blacklistResult = runGate(requiredResult.survivors, (j) =>
+    explainBlacklistedLocationsGate(j, settings),
+  );
+  const skillResult = runGate(blacklistResult.survivors, (j) => explainSkillMatchGate(j, settings));
+  const globalModeResult = runGate(skillResult.survivors, (j) =>
+    j.mode === "global" ? explainGlobalModeGate(j, settings) : { pass: true, reason: null },
   );
 
-  // Stage 4: Gemini filter — skipped when no key, fails open on error
-  const geminiFiltered = geminiApiKey
-    ? await filterJobsWithGemini(geminiApiKey, afterGlobalModeFilter, settings)
-    : afterGlobalModeFilter.map((j) => ({
-        ...j,
-        gemini_pass: true,
-        gemini_reason: null,
-        gemini_reviewed: false,
-        gemini_quota_exhausted: false,
+  // Gemini stage — verbose variant keeps failures (with reason) instead of
+  // silently dropping them, at zero extra API cost over the old behavior
+  // (same batched calls, just a fuller return shape).
+  const geminiPool = globalModeResult.survivors;
+  const geminiDecisions = geminiApiKey
+    ? await filterJobsWithGeminiVerbose(geminiApiKey, geminiPool, settings)
+    : geminiPool.map((j) => ({
+        id: j.id,
+        pass: true,
+        reason: null as string | null,
+        reviewed: false,
+        quotaExhausted: false,
       }));
+  const geminiById = new Map(geminiDecisions.map((d) => [d.id, d]));
 
-  // Stage 5: Score — jobs with total_score ≤ 0 are discarded here
+  const geminiSurvivors: Array<
+    RawJob & {
+      gemini_pass: boolean;
+      gemini_reason: string | null;
+      gemini_reviewed: boolean;
+      gemini_quota_exhausted: boolean;
+    }
+  > = [];
+  const geminiDropped: DroppedJobEntry[] = [];
+  for (const job of geminiPool) {
+    // geminiDecisions always has an entry for every job in geminiPool (both
+    // filterJobsWithGeminiVerbose and the no-key fallback above guarantee
+    // it) — the `!` reflects that invariant, not an assumption.
+    const d = geminiById.get(job.id)!;
+    if (d.pass) {
+      geminiSurvivors.push({
+        ...job,
+        gemini_pass: true,
+        gemini_reason: d.reason,
+        gemini_reviewed: d.reviewed,
+        gemini_quota_exhausted: d.quotaExhausted,
+      });
+    } else {
+      geminiDropped.push(toEntry(job, d.reason));
+    }
+  }
+  const geminiBreakdown: GateBreakdown = {
+    count: geminiDropped.length,
+    sample: capSample(geminiDropped),
+  };
+
+  // Scoring stage — total_score <= 0 is dropped here, same as before, now
+  // also captured with a reason for the breakdown.
   const scoredJobs: ScoredJob[] = [];
-  for (const job of geminiFiltered) {
+  const scoringDropped: DroppedJobEntry[] = [];
+  for (const job of geminiSurvivors) {
     const scored = scoreJob(
       job,
       settings,
@@ -60,26 +153,45 @@ export async function buildFeed(
       job.gemini_reviewed,
       job.gemini_quota_exhausted,
     );
-    if (scored && scored.total_score > 0) {
+    // scored === null only if scoreJob's internal seniority re-check fails —
+    // unreachable here since seniority already passed in this same pass
+    // (see explainSeniorityGate above). Falling through silently matches
+    // today's existing behavior (`if (scored && ...)`) rather than inventing
+    // a gate that can't fire in practice.
+    if (!scored) continue;
+    if (scored.total_score > 0) {
       scoredJobs.push(scored);
+    } else {
+      scoringDropped.push(toEntry(job, `final score ${scored.total_score} is not above 0`));
     }
   }
-
-  // Stage 6: Merge — deduplicates and sorts by total_score descending.
-  // Empty first arg is intentional: this is a full rebuild path, not an
-  // incremental merge — there are no pre-existing cached jobs to preserve.
-  const finalJobs = mergeJobs([], scoredJobs);
-
-  const pipelineLog: PipelineLog = {
-    total_fetched: totalFetched,
-    after_date_filter: afterDateFilter.length,
-    after_settings_filter: afterSettingsFilter.length,
-    after_gemini_filter: geminiFiltered.length,
-    after_scoring: finalJobs.length,
-    cached_at: new Date().toISOString(),
+  const scoringBreakdown: GateBreakdown = {
+    count: scoringDropped.length,
+    sample: capSample(scoringDropped),
   };
 
-  return { finalJobs, pipelineLog };
+  // Merge — deduplicates and sorts by total_score descending. Empty first
+  // arg is intentional: this is a full rebuild path, not an incremental
+  // merge — there are no pre-existing cached jobs to preserve.
+  const finalJobs = mergeJobs([], scoredJobs);
+
+  const gateLog: GateLog = {
+    candidate_window: rawJobs.length,
+    on_dashboard: finalJobs.length,
+    gates: {
+      date: dateResult.breakdown,
+      seniority: seniorityResult.breakdown,
+      excluded_keywords: excludedResult.breakdown,
+      required_keywords: requiredResult.breakdown,
+      blacklisted_locations: blacklistResult.breakdown,
+      skill_match: skillResult.breakdown,
+      global_mode: globalModeResult.breakdown,
+      gemini: geminiBreakdown,
+      scoring: scoringBreakdown,
+    },
+  };
+
+  return { finalJobs, gateLog };
 }
 
 /** Returns the list of pipeline modes enabled by the user's settings. */

--- a/src/lib/explain.ts
+++ b/src/lib/explain.ts
@@ -1,0 +1,176 @@
+// src/lib/explain.ts
+// Traces a single raw job through every pipeline gate, in production order,
+// stopping at the first failure. This is the single source of truth for
+// "why did/didn't this job make it" — used both by buildFeed's per-gate
+// pipeline breakdown (buildFeed already has the Gemini decision from its own
+// batch call, and passes it in) and by the job-trace search route (which
+// fetches a live Gemini decision for the one searched job before calling
+// this).
+//
+// Deliberately does NOT call Gemini itself — the caller supplies the result
+// (or null if the job never reached that stage / hasn't been checked yet).
+// That keeps this module gate-logic-only and keeps the cost of a full-pool
+// breakdown at zero extra Gemini calls.
+
+import {
+  explainDateGate,
+  explainSeniorityGate,
+  explainExcludedKeywordsGate,
+  explainRequiredKeywordsGate,
+  explainBlacklistedLocationsGate,
+  explainSkillMatchGate,
+  explainGlobalModeGate,
+  scoreJob,
+} from "./scoring";
+import type { RawJob, ResolvedSettings, JobMode } from "./types";
+
+export type GateName =
+  | "date"
+  | "seniority"
+  | "excluded_keywords"
+  | "required_keywords"
+  | "blacklisted_locations"
+  | "skill_match"
+  | "global_mode"
+  | "gemini"
+  | "scoring";
+
+export interface GateOutcome {
+  gate: GateName;
+  pass: boolean;
+  reason: string | null;
+}
+
+export interface JobExplanation {
+  job: RawJob;
+  /** One entry per gate actually evaluated, in pipeline order, up to and
+   *  including the first failure. If the job passed everything, every
+   *  applicable gate is present (global_mode only for mode === "global"). */
+  gates: GateOutcome[];
+  /** The gate that stopped this job, or null if it passed every stage
+   *  (including scoring) and would appear on the dashboard. */
+  stoppedAt: GateName | null;
+  /** total_score if the job reached scoring, otherwise null. */
+  finalScore: number | null;
+}
+
+/** The shape returned by GET /api/jobs/explain for one matched job — the
+ *  single source of truth for both the route and JobTraceSearch's rendering. */
+export interface JobTraceResult {
+  id: string;
+  title: string;
+  company: string;
+  mode: JobMode;
+  pipeline_match: boolean;
+  stopped_at: GateName | null;
+  gates: GateOutcome[];
+  final_score: number | null;
+  gemini_pending: boolean;
+}
+
+/** The Gemini decision for this job, if already known. Pass null when the
+ *  job hasn't been checked yet (e.g. explainJob will stop before needing it). */
+export interface GeminiDecisionInput {
+  pass: boolean;
+  reason: string | null;
+  reviewed: boolean;
+  quotaExhausted?: boolean;
+}
+
+/**
+ * Runs one job through every gate in production order (date → seniority →
+ * excluded keywords → required keywords → blacklisted locations → skill
+ * match → global-mode [global jobs only] → Gemini → scoring), stopping at
+ * the first failure.
+ *
+ * geminiResult is required to continue past the pre-Gemini gates — pass the
+ * decision from your own batch call (buildFeed) or a fresh single-job check
+ * (job-trace search). If the job would reach Gemini but no result was
+ * supplied, the trace stops early with stoppedAt: null (incomplete, not a
+ * failure) rather than guessing.
+ */
+export function explainJob(
+  job: RawJob,
+  settings: ResolvedSettings,
+  geminiResult: GeminiDecisionInput | null,
+): JobExplanation {
+  const gates: GateOutcome[] = [];
+
+  const stopAt = (gate: GateName): JobExplanation => ({
+    job,
+    gates,
+    stoppedAt: gate,
+    finalScore: null,
+  });
+
+  const date = explainDateGate(job, settings.job_age_days);
+  gates.push({ gate: "date", ...date });
+  if (!date.pass) return stopAt("date");
+
+  const seniority = explainSeniorityGate(job, settings);
+  gates.push({ gate: "seniority", ...seniority });
+  if (!seniority.pass) return stopAt("seniority");
+
+  const excluded = explainExcludedKeywordsGate(job, settings);
+  gates.push({ gate: "excluded_keywords", ...excluded });
+  if (!excluded.pass) return stopAt("excluded_keywords");
+
+  const required = explainRequiredKeywordsGate(job, settings);
+  gates.push({ gate: "required_keywords", ...required });
+  if (!required.pass) return stopAt("required_keywords");
+
+  const blacklisted = explainBlacklistedLocationsGate(job, settings);
+  gates.push({ gate: "blacklisted_locations", ...blacklisted });
+  if (!blacklisted.pass) return stopAt("blacklisted_locations");
+
+  const skillMatch = explainSkillMatchGate(job, settings);
+  gates.push({ gate: "skill_match", ...skillMatch });
+  if (!skillMatch.pass) return stopAt("skill_match");
+
+  // Global-mode gate only applies to "global" pipeline jobs — matches
+  // buildFeed's `job.mode === "global" ? passesGlobalModeGate(...) : true`.
+  if (job.mode === "global") {
+    const globalMode = explainGlobalModeGate(job, settings);
+    gates.push({ gate: "global_mode", ...globalMode });
+    if (!globalMode.pass) return stopAt("global_mode");
+  }
+
+  if (!geminiResult) {
+    // Every gate above passed but we don't have a Gemini decision to
+    // continue with. Not a failure — an incomplete trace. Caller's choice
+    // whether to fetch one and re-call, or show "pending" in the UI.
+    return { job, gates, stoppedAt: null, finalScore: null };
+  }
+
+  gates.push({ gate: "gemini", pass: geminiResult.pass, reason: geminiResult.reason });
+  if (!geminiResult.pass) return stopAt("gemini");
+
+  const scored = scoreJob(
+    job,
+    settings,
+    geminiResult.pass,
+    geminiResult.reason,
+    geminiResult.reviewed,
+    geminiResult.quotaExhausted ?? false,
+  );
+  if (!scored) {
+    // Defensive only: scoreJob's internal seniority re-check can't fail here
+    // — seniority already passed above. Treat as an incomplete trace rather
+    // than assume which stage would be responsible.
+    return { job, gates, stoppedAt: null, finalScore: null };
+  }
+
+  const scoringPass = scored.total_score > 0;
+  gates.push({
+    gate: "scoring",
+    pass: scoringPass,
+    reason: scoringPass ? null : `final score ${scored.total_score} is not above 0`,
+  });
+
+  return {
+    job,
+    gates,
+    stoppedAt: scoringPass ? null : "scoring",
+    finalScore: scored.total_score,
+  };
+}

--- a/src/lib/gemini.ts
+++ b/src/lib/gemini.ts
@@ -292,6 +292,25 @@ ${JSON.stringify(jobSummaries, null, 2)}`;
 
 // ── Main export: filter all jobs ─────────────────────────────
 
+// Shared by filterJobsWithGemini and filterJobsWithGeminiVerbose: runs every
+// job through filterBatch in BATCH_SIZE chunks and returns one decision per
+// job (pass AND fail — filterBatch already fills in a fail-open entry for
+// every job, this just doesn't throw failures away). One batching loop,
+// two different assemblies of the same data — not two Gemini call sites.
+async function filterAllJobs(
+  apiKey: string,
+  jobs: RawJob[],
+  promptTemplate: string,
+): Promise<Map<string, FilterResult>> {
+  const allDecisions = new Map<string, FilterResult>();
+  for (let i = 0; i < jobs.length; i += BATCH_SIZE) {
+    const batch = jobs.slice(i, i + BATCH_SIZE);
+    const decisions = await filterBatch(apiKey, batch, promptTemplate);
+    for (const [id, d] of decisions) allDecisions.set(id, d);
+  }
+  return allDecisions;
+}
+
 /**
  * Filters a list of raw jobs using the user's Gemini API key and custom prompt.
  * Processes jobs in batches to stay within context window limits.
@@ -314,6 +333,7 @@ export async function filterJobsWithGemini(
 > {
   if (!apiKey || !jobs.length) return [];
 
+  const decisions = await filterAllJobs(apiKey, jobs, settings.gemini_filter_prompt);
   const results: Array<
     RawJob & {
       gemini_pass: boolean;
@@ -322,28 +342,56 @@ export async function filterJobsWithGemini(
       gemini_quota_exhausted: boolean;
     }
   > = [];
-  const prompt = settings.gemini_filter_prompt;
 
-  // Process in batches
-  for (let i = 0; i < jobs.length; i += BATCH_SIZE) {
-    const batch = jobs.slice(i, i + BATCH_SIZE);
-    const decisions = await filterBatch(apiKey, batch, prompt);
-
-    for (const job of batch) {
-      const d = decisions.get(job.id);
-      if (d?.pass) {
-        results.push({
-          ...job,
-          gemini_pass: true,
-          gemini_reason: d.reason,
-          gemini_reviewed: d.reviewed,
-          gemini_quota_exhausted: d.quotaExhausted ?? false,
-        });
-      }
+  for (const job of jobs) {
+    const d = decisions.get(job.id);
+    if (d?.pass) {
+      results.push({
+        ...job,
+        gemini_pass: true,
+        gemini_reason: d.reason,
+        gemini_reviewed: d.reviewed,
+        gemini_quota_exhausted: d.quotaExhausted ?? false,
+      });
     }
   }
 
   return results;
+}
+
+export interface GeminiJobResult {
+  id: string;
+  pass: boolean;
+  reason: string | null;
+  reviewed: boolean;
+  quotaExhausted: boolean;
+}
+
+/**
+ * Same Gemini batch calls as filterJobsWithGemini — zero extra API cost —
+ * but returns a decision for EVERY job, pass or fail, instead of silently
+ * dropping failures. Used by the pipeline breakdown (buildFeed) and the
+ * job-trace search so the Gemini gate's drop reasons are visible, without
+ * re-querying Gemini a second time for the same jobs.
+ */
+export async function filterJobsWithGeminiVerbose(
+  apiKey: string,
+  jobs: RawJob[],
+  settings: Pick<ResolvedSettings, "gemini_filter_prompt">,
+): Promise<GeminiJobResult[]> {
+  if (!apiKey || !jobs.length) return [];
+
+  const decisions = await filterAllJobs(apiKey, jobs, settings.gemini_filter_prompt);
+  return jobs.map((job) => {
+    const d = decisions.get(job.id);
+    return {
+      id: job.id,
+      pass: d?.pass ?? true,
+      reason: d?.reason ?? null,
+      reviewed: d?.reviewed ?? false,
+      quotaExhausted: d?.quotaExhausted ?? false,
+    };
+  });
 }
 
 // ── Strategy generation ───────────────────────────────────────

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -48,13 +48,31 @@ export function getMatchedLevels(job: RawJob, settings: ResolvedSettings): Senio
 }
 
 /**
+ * Explain variant of the seniority gate: same pass/fail logic as
+ * passesSeniorityGate, plus a human-readable reason on failure for the
+ * pipeline breakdown / job-trace search. Reason is null on pass — nothing
+ * downstream renders a reason for jobs that survived a gate.
+ */
+export function explainSeniorityGate(
+  job: RawJob,
+  settings: ResolvedSettings,
+): { pass: boolean; reason: string | null } {
+  const matched = getMatchedLevels(job, settings);
+  if (matched.length === 0) return { pass: true, reason: null }; // unlabelled — unchanged behavior
+  const pass = matched.some((l) => settings.seniority_levels.includes(l));
+  if (pass) return { pass: true, reason: null };
+  return {
+    pass: false,
+    reason: `matched seniority level(s) [${matched.join(", ")}], none enabled [${settings.seniority_levels.join(", ")}]`,
+  };
+}
+
+/**
  * Gate logic: pass if any matched level is in the user's selected levels.
  * Unlabelled jobs (no level matches) always pass — unchanged behavior.
  */
 export function passesSeniorityGate(job: RawJob, settings: ResolvedSettings): boolean {
-  const matched = getMatchedLevels(job, settings);
-  if (matched.length === 0) return true; // unlabelled — unchanged behavior
-  return matched.some((l) => settings.seniority_levels.includes(l));
+  return explainSeniorityGate(job, settings).pass;
 }
 
 /**
@@ -202,57 +220,125 @@ export function hasRelocationSupport(job: RawJob): boolean {
 
 // ── Settings gate & Pre-filters ──────────────────────────────
 
-/** Word-boundary test: does any word in `words` appear as a whole word in `text`? */
-function matchesAnyWholeWord(text: string, words: string[]): boolean {
-  return words.some((word) => {
+/**
+ * Word-boundary search: returns the first word from `words` that appears as
+ * a whole word in `text`, or null if none match. matchesAnyWholeWord below
+ * is a thin boolean wrapper over this — one source of truth for the regex.
+ */
+function findMatchingWholeWord(text: string, words: string[]): string | null {
+  for (const word of words) {
     const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/\s+/g, "\\s+");
     const regex = new RegExp(`\\b${escaped}\\b`, "i");
-    return regex.test(text);
-  });
+    if (regex.test(text)) return word;
+  }
+  return null;
+}
+
+/** Word-boundary test: does any word in `words` appear as a whole word in `text`? */
+function matchesAnyWholeWord(text: string, words: string[]): boolean {
+  return findMatchingWholeWord(text, words) !== null;
+}
+
+/**
+ * Explain variant of the excluded-keywords gate: reports which excluded
+ * keyword matched the title on failure. Reason is null on pass.
+ */
+export function explainExcludedKeywordsGate(
+  job: RawJob,
+  settings: ResolvedSettings,
+): { pass: boolean; reason: string | null } {
+  if (!settings.excluded_keywords || settings.excluded_keywords.length === 0) {
+    return { pass: true, reason: null };
+  }
+  const matched = findMatchingWholeWord(job.title.toLowerCase(), settings.excluded_keywords);
+  if (!matched) return { pass: true, reason: null };
+  return { pass: false, reason: `title matched excluded keyword "${matched}"` };
 }
 
 /** Gate 2: job title must not contain any excluded keyword. */
 export function passesExcludedKeywordsGate(job: RawJob, settings: ResolvedSettings): boolean {
-  if (!settings.excluded_keywords || settings.excluded_keywords.length === 0) {
-    return true;
-  }
-  return !matchesAnyWholeWord(job.title.toLowerCase(), settings.excluded_keywords);
+  return explainExcludedKeywordsGate(job, settings).pass;
 }
 
-/** Gate 3: title+description+location must meaningfully match required (or fallback expert) keywords. */
-export function passesRequiredKeywordsGate(job: RawJob, settings: ResolvedSettings): boolean {
+/**
+ * Explain variant of the required-keywords gate. On failure, none of the
+ * configured (or fallback expert_skills) keywords meaningfully matched, so
+ * the reason lists the full set that was checked against — there's no
+ * single "missing" term the way there is for excluded/blacklist, since
+ * failure here means zero of them cleared the bar.
+ */
+export function explainRequiredKeywordsGate(
+  job: RawJob,
+  settings: ResolvedSettings,
+): { pass: boolean; reason: string | null } {
   const techKeywords =
     settings.required_keywords && settings.required_keywords.length > 0
       ? settings.required_keywords
       : settings.expert_skills;
 
   if (!techKeywords || techKeywords.length === 0) {
-    return true;
+    return { pass: true, reason: null };
   }
 
   const textCombined = `${job.title} ${job.description} ${job.location}`.toLowerCase();
-  return hasMeaningfulKeywordMatch(textCombined, techKeywords);
+  const pass = hasMeaningfulKeywordMatch(textCombined, techKeywords);
+  if (pass) return { pass: true, reason: null };
+  return {
+    pass: false,
+    reason: `none of your required keywords matched: ${techKeywords.join(", ")}`,
+  };
+}
+
+/** Gate 3: title+description+location must meaningfully match required (or fallback expert) keywords. */
+export function passesRequiredKeywordsGate(job: RawJob, settings: ResolvedSettings): boolean {
+  return explainRequiredKeywordsGate(job, settings).pass;
+}
+
+/**
+ * Explain variant of the blacklisted-locations gate: reports which
+ * blacklisted term matched on failure. Reason is null on pass.
+ */
+export function explainBlacklistedLocationsGate(
+  job: RawJob,
+  settings: ResolvedSettings,
+): { pass: boolean; reason: string | null } {
+  if (!settings.blacklisted_locations || settings.blacklisted_locations.length === 0) {
+    return { pass: true, reason: null };
+  }
+  const textCombined = `${job.title} ${job.description} ${job.location}`.toLowerCase();
+  const matched = settings.blacklisted_locations.find(
+    (word) =>
+      matchesAnyWholeWord(textCombined, [word]) || textCombined.includes(word.toLowerCase()),
+  );
+  if (!matched) return { pass: true, reason: null };
+  return { pass: false, reason: `matched blacklisted location/term "${matched}"` };
 }
 
 /** Gate 4: title+description+location must not contain a blacklisted location. */
 export function passesBlacklistedLocationsGate(job: RawJob, settings: ResolvedSettings): boolean {
-  if (!settings.blacklisted_locations || settings.blacklisted_locations.length === 0) {
-    return true;
-  }
-  const textCombined = `${job.title} ${job.description} ${job.location}`.toLowerCase();
-  const hasBlacklisted = settings.blacklisted_locations.some(
-    (word) =>
-      matchesAnyWholeWord(textCombined, [word]) || textCombined.includes(word.toLowerCase()),
-  );
-  return !hasBlacklisted;
+  return explainBlacklistedLocationsGate(job, settings).pass;
+}
+
+/**
+ * Explain variant of the skill-match floor: reason is a flat statement on
+ * failure (no single "matched term" concept — failure means nothing in
+ * expert_skills or secondary_skills cleared the boilerplate-aware bar).
+ */
+export function explainSkillMatchGate(
+  job: RawJob,
+  settings: ResolvedSettings,
+): { pass: boolean; reason: string | null } {
+  const pass = hasMeaningfulKeywordMatch(job.description, [
+    ...settings.expert_skills,
+    ...settings.secondary_skills,
+  ]);
+  if (pass) return { pass: true, reason: null };
+  return { pass: false, reason: "no expert or secondary skill found in the job description" };
 }
 
 /** Gate 5: job description must meaningfully match the user's expert or secondary skills. */
 export function passesSkillMatchGate(job: RawJob, settings: ResolvedSettings): boolean {
-  return hasMeaningfulKeywordMatch(job.description, [
-    ...settings.expert_skills,
-    ...settings.secondary_skills,
-  ]);
+  return explainSkillMatchGate(job, settings).pass;
 }
 
 /**
@@ -272,41 +358,72 @@ export function passesSettingsGate(job: RawJob, settings: ResolvedSettings): boo
 // ── Global mode gate ────────────────────────────────────────
 
 /**
- * Evaluates whether a job passes the user's global mode timezone/region filter.
+ * Explain variant of the global-mode gate: reports whether an allowed
+ * location short-circuited the check, or which blocked region caused a
+ * failure. Reason is null whenever the gate passes.
  */
-export function passesGlobalModeGate(job: RawJob, settings: ResolvedSettings): boolean {
+export function explainGlobalModeGate(
+  job: RawJob,
+  settings: ResolvedSettings,
+): { pass: boolean; reason: string | null } {
   const text = `${job.title} ${job.description} ${job.location}`.toLowerCase();
 
   if (settings.global_mode_allowed_locations?.length) {
     const isAllowed = settings.global_mode_allowed_locations.some((loc) =>
       text.includes(loc.toLowerCase()),
     );
-    if (isAllowed) return true;
+    if (isAllowed) return { pass: true, reason: null };
   }
 
   if (settings.global_mode_blocked_regions?.length) {
-    const isBlocked = settings.global_mode_blocked_regions.some((region) => {
+    const blockedMatch = settings.global_mode_blocked_regions.find((region) => {
       const escaped = region.replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/\s+/g, "\\s+");
       const regex = new RegExp(`\\b${escaped}\\b`, "i");
       return regex.test(text);
     });
-    if (isBlocked) return false;
+    if (blockedMatch) {
+      return { pass: false, reason: `matched blocked region "${blockedMatch}"` };
+    }
   }
 
-  return true;
+  return { pass: true, reason: null };
+}
+
+/**
+ * Evaluates whether a job passes the user's global mode timezone/region filter.
+ */
+export function passesGlobalModeGate(job: RawJob, settings: ResolvedSettings): boolean {
+  return explainGlobalModeGate(job, settings).pass;
 }
 
 // ── Date gate ────────────────────────────────────────────────
 
 /**
+ * Explain variant of the date gate: reports the job's age and the
+ * configured limit on failure. Reason is null on pass.
+ */
+export function explainDateGate(
+  job: RawJob,
+  maxAgeDays: number,
+): { pass: boolean; reason: string | null } {
+  const dateStr = job.date_unknown ? job.fetched_at : job.posted_at;
+  const ms = Date.parse(dateStr);
+  if (Number.isNaN(ms)) {
+    return { pass: false, reason: "posted/fetched date could not be parsed" };
+  }
+  const ageDays = (Date.now() - ms) / 86_400_000;
+  if (ageDays <= maxAgeDays) return { pass: true, reason: null };
+  return {
+    pass: false,
+    reason: `job is ${Math.round(ageDays)}d old, your limit is ${maxAgeDays}d`,
+  };
+}
+
+/**
  * Returns true if the job is within the configured age window.
  */
 export function passesDateGate(job: RawJob, maxAgeDays: number): boolean {
-  const dateStr = job.date_unknown ? job.fetched_at : job.posted_at;
-  const ms = Date.parse(dateStr);
-  if (Number.isNaN(ms)) return false;
-  const ageDays = (Date.now() - ms) / 86_400_000;
-  return ageDays <= maxAgeDays;
+  return explainDateGate(job, maxAgeDays).pass;
 }
 
 // ── Main scoring function ────────────────────────────────────

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -232,14 +232,90 @@ export interface UserProfile {
 
 // ── Pipeline Log (stored in user_jobs_cache.pipeline_log) ───
 
-export interface PipelineLog {
-  total_fetched: number;
-  after_date_filter: number;
-  after_settings_filter: number;
-  /** Jobs that passed the Gemini gate, before scoring/merge. */
-  after_gemini_filter: number;
-  /** Final jobs shown on the dashboard, after scoring (total_score > 0) and merge. */
-  after_scoring: number;
+/** Max jobs kept per gate/section in the stored breakdown — bounded so the
+ *  cached payload (returned on every /api/dashboard load, not just /pipeline)
+ *  stays cheap regardless of how skewed one gate's drop rate is. The exact
+ *  count is never capped, only the itemized sample; the job-trace search
+ *  exists precisely so a job outside the top N is still findable. */
+export const MAX_PIPELINE_SAMPLE = 50;
+
+export interface DroppedJobEntry {
+  id: string;
+  title: string;
+  company: string;
+  /** Why this specific job was dropped at this gate. Null only appears in
+   *  practice for entries that are never null by construction (kept nullable
+   *  for shape-symmetry with GateOutcome, not because a real drop lacks one). */
+  reason: string | null;
+}
+
+export interface WrongModeEntry {
+  id: string;
+  title: string;
+  company: string;
+  mode: JobMode;
+}
+
+export interface OutsideWindowEntry {
+  id: string;
+  title: string;
+  company: string;
+  fetched_at: string;
+}
+
+export interface GateBreakdown {
+  /** True count of jobs dropped at this gate — never capped. */
+  count: number;
+  /** Up to MAX_PIPELINE_SAMPLE jobs, most-recently-fetched first. */
+  sample: DroppedJobEntry[];
+}
+
+/** The 9 real pipeline gates, in production order. */
+export interface GateBreakdowns {
+  date: GateBreakdown;
+  seniority: GateBreakdown;
+  excluded_keywords: GateBreakdown;
+  required_keywords: GateBreakdown;
+  blacklisted_locations: GateBreakdown;
+  skill_match: GateBreakdown;
+  global_mode: GateBreakdown;
+  gemini: GateBreakdown;
+  scoring: GateBreakdown;
+}
+
+/** buildFeed's own responsibility: the gate-by-gate breakdown of the
+ *  candidate pool it was handed, plus the final survivor count. Doesn't
+ *  know about ingestion-level losses — those happen before buildFeed ever
+ *  runs and require DB queries buildFeed (pure, no Supabase client) can't make. */
+export interface GateLog {
+  /** Size of the candidate pool buildFeed actually received (post mode-filter, post 2000-cap). */
+  candidate_window: number;
+  /** Final jobs shown on the dashboard, after every gate + scoring + merge. */
+  on_dashboard: number;
+  gates: GateBreakdowns;
+}
+
+/** route.ts's responsibility: losses that happen before a job ever enters
+ *  the candidate pool, so no gate ever sees them. Sequential, not parallel —
+ *  outside_candidate_window can only ever remove jobs that already passed
+ *  the mode filter, so its count can never exceed wrong_pipeline_mode's pool. */
+export interface IngestionLog {
+  /** Every raw_jobs row, any mode — the true top of the funnel. */
+  total_scraped: number;
+  /** raw_jobs rows matching the user's enabled pipeline(s), before the 2000-row cap. */
+  matched_pipelines: number;
+  wrong_pipeline_mode: {
+    count: number;
+    enabled_pipelines: string[];
+    sample: WrongModeEntry[];
+  };
+  outside_candidate_window: {
+    count: number;
+    sample: OutsideWindowEntry[];
+  };
+}
+
+export interface PipelineLog extends GateLog, IngestionLog {
   cached_at: string;
 }
 


### PR DESCRIPTION
Collapses issue #53 ("add more details into pipeline page") with the separate job-lookup need into one change, per the scope decision already made on #53: aggregate counts alone can't answer "why didn't job X show up," and a standalone lookup tool would just duplicate the gate logic. This gives every gate a list of which jobs it dropped and why, and adds a raw-pool search for jobs that never entered the candidate pool at all.

Backend
- scoring.ts: passesXGate() booleans now delegate to sibling explainXGate() functions that also return a reason on failure (matched excluded/ blacklisted term, missing required keywords, seniority mismatch, blocked region, age over limit). Public signatures and behavior are unchanged — the full pre-existing gate test suite passes without modification.
- gemini.ts: filterJobsWithGemini() is untouched (same batching, same pass-only return, same tests, zero behavior change). Added filterJobsWithGeminiVerbose(), a sibling built on the same shared batch loop, that also surfaces failures with their reason instead of discarding them — zero extra Gemini calls over today.
- explain.ts (new): explainJob() traces one job through the real 9-gate production order, short-circuiting at the first failure. Takes the Gemini decision as an argument instead of calling Gemini itself, so buildFeed can reuse its one batch call for the full-pool breakdown at zero extra API cost, and the search route can inject a fresh single-job decision.
- dashboard-route.ts (buildFeed): now returns a GateLog with, per gate, a true (uncapped) drop count plus a sample of up to 50 dropped jobs (title/company/reason), ordered most-recently-fetched-first. Switched to filterJobsWithGeminiVerbose so Gemini's drop reasons are captured without re-querying Gemini.
- dashboard/route.ts: added the ingestion-level ("before any gate runs") breakdown — wrong pipeline mode and outside-the-2000-row-cap losses — computed via count-only and range queries run in parallel with the existing candidate-pool query. Sequential by construction: cap loss can never exceed mode-mismatch loss, matching how the two actually relate.
- jobs/explain/route.ts (new): GET, searches raw_jobs directly with no mode filter and no 2000-row cap, runs each match through explainJob(), fetching a live Gemini decision only for jobs that survive every earlier gate. Auth via getUser() + resolveUserSettings(), matching /api/dashboard — this is a user checking their own settings, not an admin action.
- types.ts: PipelineLog restructured from 5 flat integers into GateLog (buildFeed's responsibility) + IngestionLog (route.ts's responsibility), each gate/section carrying a count and a capped, typed sample.

Frontend
- FunnelView.tsx: rewritten as three connected funnel tiles (scraped → matched pipelines → candidate window), two ingestion-loss accordions, nine per-gate accordions in production order, and a final "on your dashboard" tile. Ingestion-loss rows share the same accordion styling as the gate rows (explicit call, not a default).
- GateAccordionRow.tsx (new): the shared expandable row used by all 11 breakdown sections — count, hover description, and an expandable title/company/detail table when there's something to show.
- JobTraceSearch.tsx (new): the "can't find it in the lists above?" search box — title/company inputs, renders each match's pipeline-match status, which gate stopped it (if any) and why, or its final score.

Data-shape decisions worth flagging
- Per-gate sample cap: 50 jobs, most-recent-first. The true count is never capped — only the itemized list, since pipeline_log is returned on every /api/dashboard load (not just the /pipeline page), so an uncapped list would add payload weight to the main dashboard's hot path for a case the search box already covers.
- Gemini reuse: buildFeed's per-gate breakdown never triggers an extra Gemini call. explain.ts stays Gemini-call-agnostic by design (see above).

Known gaps
- e2e/pipeline.spec.ts assertions were rewritten to match the new labels/shape, verified to parse and list correctly (`playwright test --list`), but could not be executed end-to-end in this environment (no live Supabase credentials / running server here) — run it for real before merging.
- ESLint complexity warnings (non-blocking, consistent with existing accepted warnings elsewhere in the repo): dashboard/route.ts GET (14, vs. existing account/route.ts DELETE at 14) and explain.ts explainJob (15, an inherent property of a linear 9-gate cascade).

Tests: 448/448 (`pnpm vitest run`), `pnpm tsc --noEmit` clean, `pnpm lint` introduces no new blocking issues.